### PR TITLE
Merge maintenance/remove-interfaces-namespace-from-core-package into develop

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -24,8 +24,11 @@ It contains helper classes for e.g. convinience argument null checks and interfa
 
   <ItemGroup>
     <Compile Remove="Interfaces\EventCommunication\**" />
+    <Compile Remove="Interfaces\ExceptionHandling\**" />
     <EmbeddedResource Remove="Interfaces\EventCommunication\**" />
+    <EmbeddedResource Remove="Interfaces\ExceptionHandling\**" />
     <None Remove="Interfaces\EventCommunication\**" />
+    <None Remove="Interfaces\ExceptionHandling\**" />
     <None Include="..\..\LICENSE.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -36,9 +39,8 @@ It contains helper classes for e.g. convinience argument null checks and interfa
     <Compile Remove="Class1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Interfaces\MVVM\" />
+    <Folder Include="MVVM\" />
     <Folder Include="Interfaces\Navigation\" />
-    <Folder Include="Interfaces\ExceptionHandling\" />
     <Folder Include="Interfaces\Navigation\ViewModels\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -23,12 +23,6 @@ It contains helper classes for e.g. convinience argument null checks and interfa
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Interfaces\EventCommunication\**" />
-    <Compile Remove="Interfaces\ExceptionHandling\**" />
-    <EmbeddedResource Remove="Interfaces\EventCommunication\**" />
-    <EmbeddedResource Remove="Interfaces\ExceptionHandling\**" />
-    <None Remove="Interfaces\EventCommunication\**" />
-    <None Remove="Interfaces\ExceptionHandling\**" />
     <None Include="..\..\LICENSE.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -40,8 +34,7 @@ It contains helper classes for e.g. convinience argument null checks and interfa
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MVVM\" />
-    <Folder Include="Interfaces\Navigation\" />
-    <Folder Include="Interfaces\Navigation\ViewModels\" />
+    <Folder Include="Navigation\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.2" />

--- a/src/Core/DependencyInjection/IDependencyContainer.cs
+++ b/src/Core/DependencyInjection/IDependencyContainer.cs
@@ -1,4 +1,4 @@
-﻿namespace CodeMonkeys.Core.Interfaces.DependencyInjection
+﻿namespace CodeMonkeys.Core.DependencyInjection
 {
     public interface IDependencyContainer :
         IDependencyRegister,

--- a/src/Core/DependencyInjection/IDependencyRegister.cs
+++ b/src/Core/DependencyInjection/IDependencyRegister.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CodeMonkeys.Core.Interfaces.DependencyInjection
+namespace CodeMonkeys.Core.DependencyInjection
 {
     public interface IDependencyRegister
     {

--- a/src/Core/DependencyInjection/IDependencyResolver.cs
+++ b/src/Core/DependencyInjection/IDependencyResolver.cs
@@ -1,4 +1,4 @@
-﻿namespace CodeMonkeys.Core.Interfaces.DependencyInjection
+﻿namespace CodeMonkeys.Core.DependencyInjection
 {
     public interface IDependencyResolver
     {

--- a/src/Core/Interfaces/Navigation/IViewModelNavigationService.cs
+++ b/src/Core/Interfaces/Navigation/IViewModelNavigationService.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
+using CodeMonkeys.Core.MVVM;
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
 
 namespace CodeMonkeys.Core.Interfaces.Navigation
 {

--- a/src/Core/MVVM/IViewModel.cs
+++ b/src/Core/MVVM/IViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.MVVM
+namespace CodeMonkeys.Core.MVVM
 {
     public interface IViewModel
     {

--- a/src/Core/MVVM/IViewModelT.cs
+++ b/src/Core/MVVM/IViewModelT.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.MVVM
+namespace CodeMonkeys.Core.MVVM
 {
     public interface IViewModel<TModel> :
         IViewModel

--- a/src/Core/Navigation/INavigationRegistration.cs
+++ b/src/Core/Navigation/INavigationRegistration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CodeMonkeys.Core.Interfaces.Navigation
+namespace CodeMonkeys.Core.Navigation
 {
     public interface INavigationRegistration
     {

--- a/src/Core/Navigation/IViewModelNavigationService.cs
+++ b/src/Core/Navigation/IViewModelNavigationService.cs
@@ -1,10 +1,10 @@
-﻿using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
-using CodeMonkeys.Core.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation.ViewModels;
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.Navigation
+namespace CodeMonkeys.Core.Navigation
 {
     public interface IViewModelNavigationService
     {

--- a/src/Core/Navigation/ViewModels/IHandleClosing.cs
+++ b/src/Core/Navigation/ViewModels/IHandleClosing.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.Navigation.ViewModels
+namespace CodeMonkeys.Core.Navigation.ViewModels
 {
     public interface IHandleClosing
     {

--- a/src/Core/Navigation/ViewModels/IListenToChildViewModelClosing.cs
+++ b/src/Core/Navigation/ViewModels/IListenToChildViewModelClosing.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.Navigation.ViewModels
+namespace CodeMonkeys.Core.Navigation.ViewModels
 {
     public interface IListenToChildViewModelClosing
     {

--- a/src/Core/Navigation/ViewModels/IListenToChildViewModelClosingT.cs
+++ b/src/Core/Navigation/ViewModels/IListenToChildViewModelClosingT.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Interfaces.Navigation.ViewModels
+namespace CodeMonkeys.Core.Navigation.ViewModels
 {
     public interface IListenToChildViewModelClosing<TResult>
     {

--- a/src/Dependency Injection/Core/DependencyContainerFactoryBase.cs
+++ b/src/Dependency Injection/Core/DependencyContainerFactoryBase.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
-
-using CodeMonkeys.Core;
-using CodeMonkeys.Core.Interfaces.DependencyInjection;
+﻿using CodeMonkeys.Core;
+using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.Core.Logging;
 using CodeMonkeys.DependencyInjection.Core.Exceptions;
 using CodeMonkeys.Logging;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 [assembly: InternalsVisibleTo("CodeMonkeys.DependencyInjection.Ninject")]
 [assembly: InternalsVisibleTo("CodeMonkeys.DependencyInjection.DryIoC")]

--- a/src/Dependency Injection/DryIoC/DryContainer.cs
+++ b/src/Dependency Injection/DryIoC/DryContainer.cs
@@ -1,9 +1,9 @@
-﻿using CodeMonkeys.Core.Interfaces.DependencyInjection;
+﻿using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.DependencyInjection.Core;
-using DryIoc;
+
 using System;
-using System.Collections.Generic;
-using System.Text;
+
+using DryIoc;
 
 namespace CodeMonkeys.DependencyInjection.DryIoC
 {

--- a/src/Dependency Injection/DryIoC/DryFactory.cs
+++ b/src/Dependency Injection/DryIoC/DryFactory.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Interfaces.DependencyInjection;
+﻿using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.Core.Logging;
 using CodeMonkeys.DependencyInjection.Core;
 

--- a/src/Dependency Injection/Ninject/Ninject.csproj
+++ b/src/Dependency Injection/Ninject/Ninject.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Logging\Logging\Logging.csproj" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 

--- a/src/Dependency Injection/Ninject/NinjectContainer.cs
+++ b/src/Dependency Injection/Ninject/NinjectContainer.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-
-using CodeMonkeys.Core.Interfaces.DependencyInjection;
+﻿using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.DependencyInjection.Core;
 using CodeMonkeys.Logging;
+
+using System;
+using System.Collections.Generic;
 
 using Ninject;
 

--- a/src/Dependency Injection/Ninject/NinjectFactory.cs
+++ b/src/Dependency Injection/Ninject/NinjectFactory.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Interfaces.DependencyInjection;
+﻿using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.Core.Logging;
 using CodeMonkeys.DependencyInjection.Core;
 

--- a/src/MVVM/Factories/ViewModelFactory.cs
+++ b/src/MVVM/Factories/ViewModelFactory.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Threading.Tasks;
-
+﻿using CodeMonkeys.Core.DependencyInjection;
 using CodeMonkeys.Core.Helpers;
-using CodeMonkeys.Core.Interfaces.DependencyInjection;
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
 using CodeMonkeys.Core.Logging;
+using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
 using CodeMonkeys.Logging;
+
+using System;
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.Factories
 {

--- a/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-using CodeMonkeys.Core.Interfaces.MVVM;
+using CodeMonkeys.Core.MVVM;
 using CodeMonkeys.Core.Interfaces.Navigation;
 using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
 using CodeMonkeys.MVVM.Factories;

--- a/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
-
-using CodeMonkeys.Core.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Core.Navigation.ViewModels;
 using CodeMonkeys.MVVM.Factories;
+
+using System;
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.ViewModels.Navigation
 {

--- a/src/MVVM/ViewModels/Navigation/ViewModelBaseHelper.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBaseHelper.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
 
 namespace CodeMonkeys.MVVM.ViewModels.Navigation
 {

--- a/src/MVVM/ViewModels/Navigation/ViewModelBaseT.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBaseT.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using CodeMonkeys.Core.MVVM;
 
-using CodeMonkeys.Core.Interfaces.MVVM;
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.ViewModels.Navigation
 {

--- a/src/MVVM/ViewModels/Navigation/ViewModelBaseTT.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBaseTT.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using CodeMonkeys.Core.MVVM;
 
-using CodeMonkeys.Core.Interfaces.MVVM;
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.ViewModels.Navigation
 {

--- a/src/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/MVVM/ViewModels/ViewModelBase.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
 using CodeMonkeys.MVVM.PropertyChanged;
+
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.ViewModels
 {

--- a/src/MVVM/ViewModels/ViewModelBaseT.cs
+++ b/src/MVVM/ViewModels/ViewModelBaseT.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
 using CodeMonkeys.MVVM.PropertyChanged;
+
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.MVVM.ViewModels
 {

--- a/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistration.cs
+++ b/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistration.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using CodeMonkeys.Core.Navigation;
 
-using CodeMonkeys.Core.Interfaces.Navigation;
+using System;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms.Models
 {

--- a/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTT.cs
+++ b/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTT.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Interfaces.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
 
 using System;
 

--- a/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTTT.cs
+++ b/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTTT.cs
@@ -1,6 +1,7 @@
-﻿using CodeMonkeys.Core.Interfaces.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
 
 using System;
+
 using Xamarin.Forms;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms.Models

--- a/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTTTT.cs
+++ b/src/Navigation/Xamarin.Forms/Models/Registration/NavigationRegistrationTTTT.cs
@@ -1,5 +1,7 @@
-﻿using CodeMonkeys.Core.Interfaces.MVVM;
+﻿using CodeMonkeys.Core.MVVM;
+
 using System;
+
 using Xamarin.Forms;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms.Models

--- a/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.cache.cs
+++ b/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.cache.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-using CodeMonkeys.Core.Interfaces.Navigation;
+﻿using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Logging;
 using CodeMonkeys.Navigation.Xamarin.Forms.Models;
 
 using Activator = CodeMonkeys.Core.Helpers.Activator;
-using CodeMonkeys.Logging;
+
+using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {

--- a/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.close.cs
+++ b/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.close.cs
@@ -1,10 +1,10 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Core.Navigation.ViewModels;
 using CodeMonkeys.Logging;
+
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {

--- a/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿using CodeMonkeys.Core.DependencyInjection;
+using CodeMonkeys.Core.Logging;
+using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Core.Navigation.ViewModels;
+using CodeMonkeys.Logging;
+using CodeMonkeys.Navigation.Xamarin.Forms.Models;
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -7,14 +15,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
-
-using CodeMonkeys.Core.Interfaces.DependencyInjection;
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
-using CodeMonkeys.Navigation.Xamarin.Forms.Models;
-using CodeMonkeys.Core.Logging;
-using CodeMonkeys.Logging;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {

--- a/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.registration.cs
+++ b/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.registration.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Linq;
+﻿using CodeMonkeys.Core.Helpers;
+using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Logging;
+using CodeMonkeys.Navigation.Xamarin.Forms.Models;
+
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
-
-using CodeMonkeys.Core.Helpers;
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Navigation.Xamarin.Forms.Models;
-using CodeMonkeys.Logging;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {

--- a/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.show.cs
+++ b/src/Navigation/Xamarin.Forms/Service/ViewModelNavigationService.show.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Core.Navigation.ViewModels;
+using CodeMonkeys.Logging;
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Core.Interfaces.Navigation.ViewModels;
-using CodeMonkeys.Logging;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {

--- a/src/Navigation/Xamarin.Forms/ViewModelNavigationServiceExtensions.cs
+++ b/src/Navigation/Xamarin.Forms/ViewModelNavigationServiceExtensions.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using CodeMonkeys.Core.MVVM;
+using CodeMonkeys.Core.Navigation;
+using CodeMonkeys.Navigation.Xamarin.Forms.Models;
+
+using System;
 
 using Xamarin.Forms;
-
-using CodeMonkeys.Core.Interfaces.MVVM;
-using CodeMonkeys.Core.Interfaces.Navigation;
-using CodeMonkeys.Navigation.Xamarin.Forms.Models;
 
 namespace CodeMonkeys.Navigation.Xamarin.Forms
 {


### PR DESCRIPTION
As described in issue #29 I moved all the projects under the Core namespace and removed the Interfaces namespace. Also did some refactoring regarding namespace order