### PR TITLE
Merge refactoring/remove-core-namespace into develop

### DIFF
--- a/src/Core/Activator.cs
+++ b/src/Core/Activator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace CodeMonkeys.Core.Helpers
+namespace CodeMonkeys
 {
     /// <summary>
     /// Expression based Activator implementation.

--- a/src/Core/Configuration/Options.cs
+++ b/src/Core/Configuration/Options.cs
@@ -2,7 +2,7 @@
 
 using System.Threading;
 
-namespace CodeMonkeys.Core.Configuration
+namespace CodeMonkeys.Configuration
 {
     public abstract class Options
     {

--- a/src/Core/Configuration/OptionsChangeToken.cs
+++ b/src/Core/Configuration/OptionsChangeToken.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Threading;
 
-namespace CodeMonkeys.Core.Configuration
+namespace CodeMonkeys.Configuration
 {
     public class OptionsChangeToken : IChangeToken
     {

--- a/src/Core/Configuration/OptionsConsumer.cs
+++ b/src/Core/Configuration/OptionsConsumer.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace CodeMonkeys.Core.Configuration
+namespace CodeMonkeys.Configuration
 {
     public abstract class OptionsConsumer<TOptions>
         where TOptions : Options

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <RootNamespace>CodeMonkeys.Core</RootNamespace>
+    <RootNamespace>CodeMonkeys</RootNamespace>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <ReleaseVersion>2.0</ReleaseVersion>
     <AssemblyName>CodeMonkeys.Core</AssemblyName>

--- a/src/Core/Guards/Argument/Argument.Number.cs
+++ b/src/Core/Guards/Argument/Argument.Number.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     public static partial class Argument
     {

--- a/src/Core/Guards/Argument/Argument.String.cs
+++ b/src/Core/Guards/Argument/Argument.String.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     public static partial class Argument
     {

--- a/src/Core/Guards/Argument/Argument.cs
+++ b/src/Core/Guards/Argument/Argument.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     /// <summary>
     /// Contains various helper methods for verifying method parameters.

--- a/src/Core/Guards/Property/Property.Number.cs
+++ b/src/Core/Guards/Property/Property.Number.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     public static partial class Property
     {

--- a/src/Core/Guards/Property/Property.String.cs
+++ b/src/Core/Guards/Property/Property.String.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     public static partial class Property
     {

--- a/src/Core/Guards/Property/Property.cs
+++ b/src/Core/Guards/Property/Property.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace CodeMonkeys.Core
+namespace CodeMonkeys
 {
     [DebuggerNonUserCode]
     [DebuggerStepThrough]

--- a/src/Core/TaskHelper.cs
+++ b/src/Core/TaskHelper.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CodeMonkeys.Core.Helpers
+namespace CodeMonkeys
 {
     /// <summary>
     /// Contains various helper methods for working with tasks.

--- a/src/DependencyInjection/DependencyInjection/DependencyContainerFactoryBase.cs
+++ b/src/DependencyInjection/DependencyInjection/DependencyContainerFactoryBase.cs
@@ -1,9 +1,8 @@
-﻿using CodeMonkeys.Core;
-using CodeMonkeys.Logging;
+﻿using CodeMonkeys.Logging;
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+
 
 [assembly: InternalsVisibleTo("CodeMonkeys.DependencyInjection.Ninject")]
 [assembly: InternalsVisibleTo("CodeMonkeys.DependencyInjection.DryIoC")]

--- a/src/Dialogs/Dialogs.Xamarin.Forms/DialogService.cs
+++ b/src/Dialogs/Dialogs.Xamarin.Forms/DialogService.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 using System;
 using System.Threading.Tasks;

--- a/src/Dialogs/Dialogs/DialogOptions.cs
+++ b/src/Dialogs/Dialogs/DialogOptions.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 namespace CodeMonkeys.Dialogs
 {

--- a/src/Dialogs/Dialogs/Extensions/DialogServiceExtensions.cs
+++ b/src/Dialogs/Dialogs/Extensions/DialogServiceExtensions.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-namespace CodeMonkeys.Dialogs
+﻿namespace CodeMonkeys.Dialogs
 {
     public static class DialogServiceExtensions
     {

--- a/src/Logging/Logging.Batching/BatchingLogOptions.cs
+++ b/src/Logging/Logging.Batching/BatchingLogOptions.cs
@@ -1,5 +1,4 @@
-﻿using CodeMonkeys.Core;
-using CodeMonkeys.Logging.Configuration;
+﻿using CodeMonkeys.Logging.Configuration;
 
 using System;
 

--- a/src/Logging/Logging.Console/ConsoleLogService.cs
+++ b/src/Logging/Logging.Console/ConsoleLogService.cs
@@ -1,4 +1,4 @@
-﻿using static CodeMonkeys.Core.Argument;
+﻿using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging.Console/ConsoleLogServiceProvider.cs
+++ b/src/Logging/Logging.Console/ConsoleLogServiceProvider.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-namespace CodeMonkeys.Logging.Console
+﻿namespace CodeMonkeys.Logging.Console
 {
     public sealed class ConsoleLogServiceProvider : LogServiceProvider<ConsoleLogOptions>
     {

--- a/src/Logging/Logging.Console/LogServiceFactory.Console.Extensions.cs
+++ b/src/Logging/Logging.Console/LogServiceFactory.Console.Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using CodeMonkeys.Logging.Console;
 
-using static CodeMonkeys.Core.Argument;
+using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging.Debug/DebugLogService.cs
+++ b/src/Logging/Logging.Debug/DebugLogService.cs
@@ -1,4 +1,4 @@
-﻿using static CodeMonkeys.Core.Argument;
+﻿using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging.Debug/DebugLogServiceProvider.cs
+++ b/src/Logging/Logging.Debug/DebugLogServiceProvider.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-namespace CodeMonkeys.Logging.Debug
+﻿namespace CodeMonkeys.Logging.Debug
 {
     public sealed class DebugLogServiceProvider : LogServiceProvider<DebugLogOptions>
     {

--- a/src/Logging/Logging.Debug/LogServiceFactory.Debug.Extensions.cs
+++ b/src/Logging/Logging.Debug/LogServiceFactory.Debug.Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using CodeMonkeys.Logging.Debug;
 
-using static CodeMonkeys.Core.Argument;
+using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging.File/FileLogService.cs
+++ b/src/Logging/Logging.File/FileLogService.cs
@@ -1,4 +1,4 @@
-﻿using static CodeMonkeys.Core.Argument;
+﻿using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging.File/FileLogServiceProvider.cs
+++ b/src/Logging/Logging.File/FileLogServiceProvider.cs
@@ -1,5 +1,4 @@
-﻿using CodeMonkeys.Core;
-using CodeMonkeys.Logging.Batching;
+﻿using CodeMonkeys.Logging.Batching;
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.File/LogServiceFactory.File.Extensions.cs
+++ b/src/Logging/Logging.File/LogServiceFactory.File.Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using CodeMonkeys.Logging.File;
-using static CodeMonkeys.Core.Argument;
+
+using static CodeMonkeys.Argument;
 
 using System;
 

--- a/src/Logging/Logging/Configuration/LogOptions.cs
+++ b/src/Logging/Logging/Configuration/LogOptions.cs
@@ -1,5 +1,4 @@
-﻿using CodeMonkeys.Core;
-using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 namespace CodeMonkeys.Logging.Configuration
 {

--- a/src/Logging/Logging/LogServiceFactory.cs
+++ b/src/Logging/Logging/LogServiceFactory.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace CodeMonkeys.Logging

--- a/src/Logging/Logging/LogServiceProvider.cs
+++ b/src/Logging/Logging/LogServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 using CodeMonkeys.Logging.Configuration;
 
 namespace CodeMonkeys.Logging

--- a/src/MVVM/Factories/ViewModelFactory.cs
+++ b/src/MVVM/Factories/ViewModelFactory.cs
@@ -1,5 +1,4 @@
-﻿using CodeMonkeys.Core.Helpers;
-using CodeMonkeys.DependencyInjection;
+﻿using CodeMonkeys.DependencyInjection;
 using CodeMonkeys.Logging;
 using CodeMonkeys.Navigation;
 

--- a/src/Messaging/Configuration/SubscriptionManagerOptions.cs
+++ b/src/Messaging/Configuration/SubscriptionManagerOptions.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 using System;
 

--- a/src/Messaging/EventAggregator.cs
+++ b/src/Messaging/EventAggregator.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Messaging/Subscription.cs
+++ b/src/Messaging/Subscription.cs
@@ -1,6 +1,4 @@
-﻿using CodeMonkeys.Core;
-
-using System;
+﻿using System;
 
 namespace CodeMonkeys.Messaging
 {

--- a/src/Navigation/Navigation.Xamarin.Forms/Service/ViewModelNavigationService.cache.cs
+++ b/src/Navigation/Navigation.Xamarin.Forms/Service/ViewModelNavigationService.cache.cs
@@ -1,6 +1,4 @@
-﻿using Activator = CodeMonkeys.Core.Helpers.Activator;
-
-using CodeMonkeys.Logging;
+﻿using CodeMonkeys.Logging;
 
 using System;
 using System.Collections.Generic;

--- a/src/Navigation/Navigation.Xamarin.Forms/Service/ViewModelNavigationService.registration.cs
+++ b/src/Navigation/Navigation.Xamarin.Forms/Service/ViewModelNavigationService.registration.cs
@@ -1,6 +1,6 @@
-﻿using CodeMonkeys.Core.Helpers;
-using CodeMonkeys.Logging;
+﻿using CodeMonkeys.Logging;
 using CodeMonkeys.MVVM;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/tests/UnitTests/Configuration/MockOptions.cs
+++ b/src/tests/UnitTests/Configuration/MockOptions.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 namespace CodeMonkeys.UnitTests.Configuration
 {

--- a/src/tests/UnitTests/Configuration/MockOptionsConsumer.cs
+++ b/src/tests/UnitTests/Configuration/MockOptionsConsumer.cs
@@ -1,4 +1,4 @@
-﻿using CodeMonkeys.Core.Configuration;
+﻿using CodeMonkeys.Configuration;
 
 namespace CodeMonkeys.UnitTests.Configuration
 {


### PR DESCRIPTION
- Removed .Core namespace
- Helpers are now contained in root namespace CodeMonkeys
- Argument and Property Guard source files are now in the Guards folder
- Activator and TaskHelper are now also in the CodeMonkeys root namespace