### PR TITLE
Merge bugfix/closeasync-throwing-exceptions into develop

### DIFF
--- a/src/Navigation/Navigation.Xamarin.Forms/Service/NavigationService.close.cs
+++ b/src/Navigation/Navigation.Xamarin.Forms/Service/NavigationService.close.cs
@@ -2,6 +2,7 @@
 using CodeMonkeys.MVVM;
 using CodeMonkeys.Navigation.ViewModels;
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -11,67 +12,72 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         INavigationService
     {
         /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface}" />
-        public virtual async Task CloseAsync<TViewModelInterface>()
+        public virtual async Task CloseAsync<TViewModel>()
 
-            where TViewModelInterface : class, IViewModel
+            where TViewModel : class, IViewModel
         {
-            var viewType = ViewModelToViewMap[typeof(TViewModelInterface)];
+            if (!TryGetRegistration(
+                typeof(TViewModel),
+                out var registration))
+            {
+                throw new InvalidOperationException();
+            }
 
-            if (!Navigation.NavigationStack.Any(
-                page => page.GetType() == viewType))
+            if (Navigation.NavigationStack.Last().GetType() != registration.ViewType)
             {
                 return;
             }
 
-            ThrowIfNotRegistered<TViewModelInterface>(
-                viewType);
-
-            var view = Navigation.NavigationStack.First(
-                page => page.GetType() == viewType);
 
             await CloseCurrentPage();
         }
 
         /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface}" />
-        public virtual async Task CloseAsync<TViewModelInterface, TParentViewModelInterface>()
+        public virtual async Task CloseAsync<TViewModel, TInterestedViewModel>()
 
-            where TViewModelInterface : class, IViewModel
-            where TParentViewModelInterface : class, IViewModel, IListenToChildViewModelClosing
+            where TViewModel : class, IViewModel
+            where TInterestedViewModel : class, IViewModel, IListenToChildViewModelClosing
         {
-            ThrowIfNotRegistered<TViewModelInterface>(
-                CurrentPage.GetType());
+            if (!TryGetRegistration(
+                typeof(TViewModel),
+                out var registration))
+            {
+                throw new InvalidOperationException();
+            }
 
-            var viewType = ViewModelToViewMap[typeof(TViewModelInterface)];
-
-            if (Navigation.NavigationStack.Last().GetType() == viewType)
+            if (Navigation.NavigationStack.Last().GetType() != registration.ViewType)
             {
                 return;
             }
 
-            await ResolveAndInformParent<TParentViewModelInterface>();
+
+            await ResolveAndInformListener<TInterestedViewModel>();
 
             await CloseCurrentPage();
         }
 
         /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface, TResult}(TResult)" />
-        public virtual async Task CloseAsync<TViewModelInterface, TParentViewModelInterface, TResult>(
-            TResult result)
+        public virtual async Task CloseAsync<TViewModel, TInterestedViewModel, TData>(
+            TData data)
 
-            where TViewModelInterface : class, IViewModel
-            where TParentViewModelInterface : class, IViewModel, IListenToChildViewModelClosing<TResult>
+            where TViewModel : class, IViewModel
+            where TInterestedViewModel : class, IViewModel, IListenToChildViewModelClosing<TData>
         {
-            ThrowIfNotRegistered<TViewModelInterface>(
-                CurrentPage.GetType());
+            if (!TryGetRegistration(
+                typeof(TViewModel),
+                out var registration))
+            {
+                throw new InvalidOperationException();
+            }
 
-            var viewType = ViewModelToViewMap[typeof(TViewModelInterface)];
-
-            if (Navigation.NavigationStack.Last().GetType() == viewType)
+            if (Navigation.NavigationStack.Last().GetType() != registration.ViewType)
             {
                 return;
             }
 
-            await ResolveAndInformParent<TParentViewModelInterface, TResult>(
-                result);
+
+            await ResolveAndInformListener<TInterestedViewModel, TData>(
+                data);
 
             await CloseCurrentPage();
         }
@@ -101,30 +107,34 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
 
-        private async Task ResolveAndInformParent<TParentViewModelInterface>()
+        private async Task ResolveAndInformListener<TInterestedViewModel>()
 
-            where TParentViewModelInterface : class, IListenToChildViewModelClosing
+            where TInterestedViewModel : class, IListenToChildViewModelClosing
         {
-            var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
+            var parentViewModel = dependencyResolver.Resolve<TInterestedViewModel>();
+
 
             Log?.Info(
-                $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
+                $"ViewModelInstance for type {typeof(TInterestedViewModel).Name} has been resolved.");
+
 
             await parentViewModel.OnChildViewModelClosingAsync();
         }
 
-        private async Task ResolveAndInformParent<TParentViewModelInterface, TResult>(
-            TResult result)
+        private async Task ResolveAndInformListener<TInterestedViewModel, TData>(
+            TData data)
 
-            where TParentViewModelInterface : class, IListenToChildViewModelClosing<TResult>
+            where TInterestedViewModel : class, IListenToChildViewModelClosing<TData>
         {
-            var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
+            var parentViewModel = dependencyResolver.Resolve<TInterestedViewModel>();
+
 
             Log?.Info(
-                $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
+                $"ViewModelInstance for type {typeof(TInterestedViewModel).Name} has been resolved.");
+
 
             await parentViewModel.OnChildViewModelClosingAsync(
-                result);
+                data);
         }
     }
 }

--- a/src/Navigation/Navigation.Xamarin.Forms/Service/NavigationService.cs
+++ b/src/Navigation/Navigation.Xamarin.Forms/Service/NavigationService.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,9 +24,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         private static IDependencyResolver dependencyResolver;
         protected static ILogService Log;
 
-
-        protected static readonly ConcurrentDictionary<Type, Type> ViewModelToViewMap =
-            new ConcurrentDictionary<Type, Type>();
 
 
         public static NavigationConfiguration Configuration { get; set; } =


### PR DESCRIPTION
I removed the deprecated `Dictionary<Type, Type> ViewModelToViewMap` from the `NavigationService`.
This dictionary was still relevant for some conditions in the `CloseAsync` methods, even though we did not populate it anymore since we introduced the `IRegistrationInfo` implementation.