### PR TITLE
added attribute to tag properties that should update command canexecute

### DIFF
--- a/samples/ViewModels/ItemViewModel.cs
+++ b/samples/ViewModels/ItemViewModel.cs
@@ -1,4 +1,5 @@
-﻿using CodeMonkeys.MVVM.Commands;
+﻿using CodeMonkeys.MVVM.Attributes;
+using CodeMonkeys.MVVM.Commands;
 
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -8,6 +9,13 @@ namespace CodeMonkeys.Samples.ViewModels
     public class ItemViewModel :
         BaseViewModel
     {
+        [IsRelevantForCommand(nameof(SelectedCommand))]
+        public bool CanSelect
+        {
+            get => GetValue<bool>();
+            set => SetValue(value);
+        }
+
         public ICommand SelectedCommand { get; }
 
 
@@ -17,13 +25,19 @@ namespace CodeMonkeys.Samples.ViewModels
             Title = title;
 
             SelectedCommand = new AsyncCommand(
-                ShowDetails);
+                ShowDetails,
+                CanShowDetails);
         }
 
         private async Task ShowDetails()
         {
             await ShowAsync<ItemDetailsViewModel, string>(
                 Title);
+        }
+
+        private bool CanShowDetails()
+        {
+            return CanSelect;
         }
     }
 }

--- a/samples/ViewModels/ItemsViewModel.cs
+++ b/samples/ViewModels/ItemsViewModel.cs
@@ -1,5 +1,7 @@
-﻿using CodeMonkeys.MVVM.Commands;
+﻿using CodeMonkeys.MVVM.Attributes;
+using CodeMonkeys.MVVM.Commands;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -14,14 +16,27 @@ namespace CodeMonkeys.Samples.ViewModels
             set => SetValue(value);
         }
         
+        [IsRelevantForCommand(nameof(ToggleSelectedItemCanSelectCommand))]
+        public ItemViewModel SelectedItem
+        {
+            get => GetValue<ItemViewModel>();
+            set => SetValue(value);
+        }
+
+
         public ICommand LoadItemsCommand { get; }
+        public ICommand ToggleSelectedItemCanSelectCommand { get; }
 
 
         public ItemsViewModel()
         {
             Title = "Browse";
             Items = new ObservableCollection<ItemViewModel>();
+
             LoadItemsCommand = new Command(GenerateItems);
+            ToggleSelectedItemCanSelectCommand = new Command(
+                ToggleItemCanSelect,
+                CanToggleItemCanSelect);
         }
 
 
@@ -46,7 +61,20 @@ namespace CodeMonkeys.Samples.ViewModels
                 Items.Add(viewModel);
             }
 
+
+            Items.First().CanSelect = true;
+
             IsBusy = false;
+        }
+
+        private void ToggleItemCanSelect()
+        {
+            SelectedItem.CanSelect = !SelectedItem.CanSelect;
+        }
+
+        private bool CanToggleItemCanSelect()
+        {
+            return SelectedItem != null;
         }
 
 

--- a/samples/WPF/SimpleNavigation/ItemsView.xaml
+++ b/samples/WPF/SimpleNavigation/ItemsView.xaml
@@ -9,8 +9,10 @@
       Title="ItemsView">
 
     <StackPanel>
-        <TextBlock Text="Items" />
-        <ListView ItemsSource="{Binding Items}">
+        <StackPanel Orientation="Horizontal">
+            <Button Content="Toggle"  Command="{Binding ToggleSelectedItemCanSelectCommand}" />
+        </StackPanel>
+        <ListView ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Button

--- a/samples/WPF/SimpleNavigation/MainWindow.xaml
+++ b/samples/WPF/SimpleNavigation/MainWindow.xaml
@@ -34,7 +34,7 @@
                 Grid.Column="0"
                 Command="{Binding NavigateBackCommand}"
                 Content="Back" />
-
+            
             <Button
                 Grid.Column="2"
                 Command="{Binding NavigateForwardCommand}"

--- a/src/MVVM/Attributes/IsRelevantForCommand.cs
+++ b/src/MVVM/Attributes/IsRelevantForCommand.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace CodeMonkeys.MVVM.Attributes
+{
+    /// <summary>
+    /// States that a property affects an ICommand's CanExecute state and should force an update on PropertyChanged
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Property,
+        Inherited = true)]
+    public class IsRelevantForCommand :
+        Attribute
+    {
+        public string CommandName { get; set; }
+
+
+        public IsRelevantForCommand()
+        {
+        }
+
+        public IsRelevantForCommand(
+            string commandName)
+        {
+            CommandName = commandName;
+        }
+    }
+}

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.cs
@@ -14,8 +14,6 @@ namespace CodeMonkeys.MVVM.PropertyChanged
     public partial class BindingBase :
         INotifyPropertyChanged
     {
-        private static ILogService _log;
-
         private static readonly Lazy<IList<PropertyDependencyWrapper>> propertyDependencies =
             new Lazy<IList<PropertyDependencyWrapper>>(
                 () => new List<PropertyDependencyWrapper>(),
@@ -48,25 +46,6 @@ namespace CodeMonkeys.MVVM.PropertyChanged
         {
             TrySetupPropertyDependencies();
             TrySetupCommandRelevantProperties();
-        }
-
-
-        private void GetLogServiceInstance()
-        {
-            var logServiceFields = GetType()
-                .GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic)
-                .Where(field => field.FieldType == typeof(ILogService));
-
-            if(!logServiceFields.Any())
-                throw new InvalidEnumArgumentException();
-
-            var logService = (ILogService)logServiceFields
-                .First()
-                .GetValue(
-                    this);
-
-
-            _log = logService ?? throw new InvalidEnumArgumentException();
         }
 
 

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.get.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.get.cs
@@ -1,5 +1,5 @@
 ﻿using CodeMonkeys.Logging;
-
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -46,19 +46,20 @@ namespace CodeMonkeys.MVVM.PropertyChanged
         /// <param name="propertyName">Name of the property to retrieves the value for</param>
         /// <exception cref="InvalidOperationException">If no field (static or instance) of type <see cref="ILogService"/> is defined</exception>
         protected TProperty GetValueAndLog<TProperty>(
+            ILogService logService,
             [CallerMemberName]string propertyName = "")
         {
-            if (_log == null)
-                GetLogServiceInstance();
-
-            _log?.Trace(
+            logService?.Trace(
                 $"Getting value for property '{propertyName}'");
+
 
             var propertyValue = GetValue<TProperty>(
                 propertyName);
 
-            _log?.Debug(
+
+            logService?.Debug(
                 $"Value for property {propertyName}: '{propertyValue}'");
+
 
             return propertyValue;
         }

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.get.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.get.cs
@@ -48,16 +48,16 @@ namespace CodeMonkeys.MVVM.PropertyChanged
         protected TProperty GetValueAndLog<TProperty>(
             [CallerMemberName]string propertyName = "")
         {
-            if (_logService == null)
+            if (_log == null)
                 GetLogServiceInstance();
 
-            _logService?.Trace(
+            _log?.Trace(
                 $"Getting value for property '{propertyName}'");
 
             var propertyValue = GetValue<TProperty>(
                 propertyName);
 
-            _logService?.Debug(
+            _log?.Debug(
                 $"Value for property {propertyName}: '{propertyValue}'");
 
             return propertyValue;

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
@@ -239,7 +239,8 @@ namespace CodeMonkeys.MVVM.PropertyChanged
                 if (commandProperty?.GetValue(this) is ICommand command)
                 {
                     InvokeCommandCanExecuteChanged(
-                        command);
+                        command,
+                        commandProperty.Name);
 
                     return;
                 }
@@ -253,12 +254,14 @@ namespace CodeMonkeys.MVVM.PropertyChanged
 
 
                 InvokeCommandCanExecuteChanged(
-                    command);
+                    command,
+                    property.Name);
             }
         }
 
         private void InvokeCommandCanExecuteChanged(
-            ICommand command)
+            ICommand command,
+            string propertyName)
         {
             if (command == null)
             {
@@ -276,9 +279,6 @@ namespace CodeMonkeys.MVVM.PropertyChanged
 
             if (eventDelegate == null)
             {
-                _log?.Error(
-                    $"Unable to get {typeof(MulticastDelegate).Name} from {command}, cannot invoke {nameof(ICommand.CanExecuteChanged)}");
-
                 return;
             }
 

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
@@ -239,8 +239,7 @@ namespace CodeMonkeys.MVVM.PropertyChanged
                 if (commandProperty?.GetValue(this) is ICommand command)
                 {
                     InvokeCommandCanExecuteChanged(
-                        command,
-                        commandProperty.Name);
+                        command);
 
                     return;
                 }
@@ -254,14 +253,12 @@ namespace CodeMonkeys.MVVM.PropertyChanged
 
 
                 InvokeCommandCanExecuteChanged(
-                    command,
-                    property.Name);
+                    command);
             }
         }
 
         private void InvokeCommandCanExecuteChanged(
-            ICommand command,
-            string propertyName)
+            ICommand command)
         {
             if (command == null)
             {

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
+using CodeMonkeys.Logging;
 using CodeMonkeys.MVVM.Attributes;
 using CodeMonkeys.MVVM.PropertyChanged.Events;
 
@@ -101,9 +102,11 @@ namespace CodeMonkeys.MVVM.PropertyChanged
 
             if (_nestedProperties.ContainsKey(
                 instance))
+            {
                 _nestedProperties.TryRemove(
                     instance,
                     out _);
+            }
         }
 
         private void AppendNestedEventListeners<TProperty>(
@@ -149,7 +152,16 @@ namespace CodeMonkeys.MVVM.PropertyChanged
             RaisePropertyChangedForDependentProperties(
                 propertyName);
 
-            UpdateCommandsCanExecute();
+
+            var commandRelevance = commandRelevantProperties.Value
+                .FirstOrDefault(relevance => relevance.PropertyName.Equals(propertyName));
+
+            if (commandRelevance != null)
+            {
+                UpdateCommandsCanExecute(
+                    commandRelevance);
+            }
+
 
             if (ShallPropertyChangedNotificationBeSuppressed(
                 propertyName))
@@ -189,7 +201,10 @@ namespace CodeMonkeys.MVVM.PropertyChanged
         private IEnumerable<PropertyInfo> GetCommandProperties()
         {
             if (commandProperties.Any())
+            {
                 return commandProperties;
+            }
+
 
             commandProperties = GetType().
                 GetProperties(
@@ -200,33 +215,80 @@ namespace CodeMonkeys.MVVM.PropertyChanged
                         propertyInfo.PropertyType is ICommand
                         || typeof(ICommand).IsAssignableFrom(propertyInfo.PropertyType));
 
+
             return commandProperties;
         }
 
-        private void UpdateCommandsCanExecute()
+        private void UpdateCommandsCanExecute(
+            CommandRelevantPropertyWrapper commandRelevance)
         {
+            if (commandRelevance == null)
+            {
+                return;
+            }
+
+
+            if (!string.IsNullOrWhiteSpace(
+                commandRelevance.CommandName))
+            {
+                var commandProperty = GetCommandProperties()
+                    .FirstOrDefault(
+                        property => property.Name == commandRelevance.CommandName);
+
+
+                if (commandProperty?.GetValue(this) is ICommand command)
+                {
+                    InvokeCommandCanExecuteChanged(
+                        command);
+
+                    return;
+                }
+            }
+
+
             foreach (var property in GetCommandProperties())
             {
                 if (!(property.GetValue(this) is ICommand command))
-                    return;
+                    continue;
 
-                var eventDelegate = (MulticastDelegate)command
-                    .GetType()
-                    .GetField(
-                        nameof(command.CanExecuteChanged),
-                        BindingFlags.Instance | BindingFlags.NonPublic)
-                    .GetValue(command);
 
-                if (eventDelegate == null)
-                    return;
+                InvokeCommandCanExecuteChanged(
+                    command);
+            }
+        }
 
-                foreach (var eventHandler in eventDelegate.GetInvocationList())
-                {
-                    eventHandler.Method
-                        .Invoke(
-                            eventHandler.Target,
-                            new object[] { command, EventArgs.Empty });
-                }
+        private void InvokeCommandCanExecuteChanged(
+            ICommand command)
+        {
+            if (command == null)
+            {
+                return;
+            }
+
+
+            var eventDelegate = (MulticastDelegate)command
+                .GetType()
+                .GetField(
+                    nameof(command.CanExecuteChanged),
+                    BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(command);
+
+
+            if (eventDelegate == null)
+            {
+                _log?.Error(
+                    $"Unable to get {typeof(MulticastDelegate).Name} from {command}, cannot invoke {nameof(ICommand.CanExecuteChanged)}");
+
+                return;
+            }
+
+
+            foreach (var eventHandler in eventDelegate.GetInvocationList())
+            {
+                eventHandler.Method
+                    .Invoke(
+                        eventHandler.Target,
+                        new object[] { command, EventArgs.Empty });
             }
         }
 

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.set.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.set.cs
@@ -123,7 +123,7 @@ namespace CodeMonkeys.MVVM.PropertyChanged
             PropertyChangingEventHandler onPropertyChanging = null,
             [CallerMemberName] string propertyName = "")
         {
-            _logService?.Trace(
+            _log?.Trace(
                 $"Setting value for property {propertyName}.");
 
             SetValue(
@@ -132,7 +132,7 @@ namespace CodeMonkeys.MVVM.PropertyChanged
                 onPropertyChanging,
                 propertyName);
 
-            _logService?.Debug(
+            _log?.Debug(
                 $"Set value for property {propertyName} to '{value}'");
         }
     }

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.set.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.set.cs
@@ -119,12 +119,14 @@ namespace CodeMonkeys.MVVM.PropertyChanged
 
         protected void SetValueAndLog<TProperty>(
             TProperty value,
+            ILogService logService,
             PropertyChangedEventHandler onPropertyChanged = null,
             PropertyChangingEventHandler onPropertyChanging = null,
             [CallerMemberName] string propertyName = "")
         {
-            _log?.Trace(
+            logService?.Trace(
                 $"Setting value for property {propertyName}.");
+
 
             SetValue(
                 value,
@@ -132,7 +134,8 @@ namespace CodeMonkeys.MVVM.PropertyChanged
                 onPropertyChanging,
                 propertyName);
 
-            _log?.Debug(
+
+            logService?.Debug(
                 $"Set value for property {propertyName} to '{value}'");
         }
     }

--- a/src/MVVM/PropertyChanged/BindingBase/CommandRelevantPropertyWrapper.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/CommandRelevantPropertyWrapper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CodeMonkeys.MVVM.PropertyChanged
+{
+    public class CommandRelevantPropertyWrapper
+    {
+        public Type Class { get; set; }
+        public string PropertyName { get; set; }
+
+        public string CommandName { get; set; }
+    }
+}

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
@@ -211,7 +211,7 @@ namespace CodeMonkeys.Navigation.WPF
             }
 
             if (typeOfView != null && 
-                !registrations.Any(registration => registration.ViewType.IsAssignableFrom(typeOfView)))
+                !registrations.Any(registration => typeOfView.IsAssignableFrom(registration.ViewType)))
             {
                 return false;
             }


### PR DESCRIPTION
- created an attribute `RelevantForCommand` to specify that the associated property should invoke `CanExecuteChange` of either all `ICommand` properties or a specified one.

Closes #106 

Example:
```csharp
public class MainViewModel
{
    [RelevantForCommand]
    public DateTime DateOfBirth
    {
        get => GetValue<DateTime>();
        set => SetValue(value);
    }
    
    public ICommand RegisterCommand =>
        new AsyncCommand(
            RegisterAsync,
            CanRegister);

    private bool CanRegister()
    {
        return (DateTime.Now.Date - DateOfBirth.Date).Years > 18;
    }
}
```

It is also possible to explicitly set the command:
```csharp
public class MainViewModel
{
    [RelevantForCommand(nameof(RegisterCommand))]
    public DateTime DateOfBirth
    {
        get => GetValue<DateTime>();
        set => SetValue(value);
    }
    
    public ICommand RegisterCommand =>
        new AsyncCommand(
            RegisterAsync,
            CanRegister);

    private bool CanRegister()
    {
        return (DateTime.Now.Date - DateOfBirth.Date).Years > 18;
    }
}
```