### PR TITLE
Merge bugfix/wpf-back-and-forward-navigation-not-bindable into develop

### DIFF
--- a/src/Navigation/WPF/Navigation.WPF.Interfaces/INavigationService.cs
+++ b/src/Navigation/WPF/Navigation.WPF.Interfaces/INavigationService.cs
@@ -8,7 +8,14 @@ namespace CodeMonkeys.Navigation.WPF
         CodeMonkeys.Navigation.INavigationService
     {
         IViewModel RootViewModel { get; }
+
         IViewModel CurrentViewModel { get; }
+
+
+        bool CanGoBack { get; }
+
+        bool CanGoForward { get; }
+
 
 
         Task SetRootWindowAsync<TRootViewModel>()
@@ -19,16 +26,16 @@ namespace CodeMonkeys.Navigation.WPF
             where TInitialViewModel : class, IViewModel;
 
 
-        bool CanGoBack();
-        bool CanGoForward();
-
         bool TryGoBack();
+
         bool TryGoForward();
 
 
 
         void ClearStacks();
+
         void ClearBackStack();
+
         void ClearForwardStack();
     }
 }

--- a/src/Navigation/WPF/Navigation.WPF.Interfaces/Navigation.WPF.Interfaces.csproj
+++ b/src/Navigation/WPF/Navigation.WPF.Interfaces/Navigation.WPF.Interfaces.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>CodeMonkeys.Navigation.WPF.Interfaces</AssemblyName>
     <RootNamespace>CodeMonkeys.Navigation</RootNamespace>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>

--- a/src/Navigation/WPF/Navigation.WPF/Navigation.WPF.csproj
+++ b/src/Navigation/WPF/Navigation.WPF/Navigation.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,7 +6,7 @@
     <AssemblyName>CodeMonkeys.Navigation.WPF</AssemblyName>
     <RootNamespace>CodeMonkeys.Navigation.WPF</RootNamespace>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>
     <Description>Package to use ViewModel navigation in WPF MVVM application</Description>
@@ -35,5 +35,4 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
@@ -63,11 +63,11 @@ namespace CodeMonkeys.Navigation.WPF
                 return Task.CompletedTask;
 
 
+            ClearStacks();
+
             SetCurrent(
                 Root.ViewModel,
                 Root.Content);
-
-            ClearStacks();
 
 
             return Task.CompletedTask;

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
@@ -36,11 +36,13 @@ namespace CodeMonkeys.Navigation.WPF
 
 
         protected IList<NavigationStackEntry> BackStack { get; set; }
+
         protected IList<WeakNavigationStackEntry> ForwardStack { get; set; }
 
 
 
         private NavigationStackEntry root;
+
         protected NavigationStackEntry Root
         {
             get => root;
@@ -48,13 +50,14 @@ namespace CodeMonkeys.Navigation.WPF
             {
                 root = value;
                 RaisePropertyChanged();
-                
+
                 RaisePropertyChanged(nameof(CurrentViewModel));
                 RaisePropertyChanged(nameof(CurrentContent));
             }
         }
 
         private NavigationStackEntry current;
+
         protected NavigationStackEntry Current
         {
             get => current;
@@ -80,7 +83,14 @@ namespace CodeMonkeys.Navigation.WPF
 
 
         public IViewModel RootViewModel => Root?.ViewModel;
+
         public IViewModel CurrentViewModel => Current?.ViewModel;
+
+
+        public bool CanGoBack => BackStack?.Any() == true;
+
+        public bool CanGoForward => IsForwardNavigationPossible();
+
 
         public FrameworkElement CurrentContent => Current?.Content;
 
@@ -137,24 +147,6 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-        public bool CanGoBack()
-        {
-            return BackStack.Any();
-        }
-
-        public bool CanGoForward()
-        {
-            var target = ForwardStack.LastOrDefault();
-
-            if (target == null)
-                return false;
-
-
-            return target.Content?.TryGetTarget(out _) == true &&
-                target.ViewModel?.TryGetTarget(out _) == true;
-        }
-
-
         public void ClearStacks()
         {
             ClearBackStack();
@@ -190,7 +182,7 @@ namespace CodeMonkeys.Navigation.WPF
                 viewModel,
                 content);
 
-            
+
 
             SetCurrent(
                 viewModel,
@@ -198,6 +190,31 @@ namespace CodeMonkeys.Navigation.WPF
 
 
             return content;
+        }
+
+        protected void RaisePropertyChanged(
+            [CallerMemberName] string propertyName = "")
+        {
+            var threadSafeCall = PropertyChanged;
+
+            threadSafeCall?.Invoke(
+                this,
+                new PropertyChangedEventArgs(
+                    propertyName));
+        }
+
+
+
+        private bool IsForwardNavigationPossible()
+        {
+            var target = ForwardStack.LastOrDefault();
+
+            if (target == null)
+                return false;
+
+
+            return target.Content?.TryGetTarget(out _) == true &&
+                target.ViewModel?.TryGetTarget(out _) == true;
         }
 
 
@@ -221,18 +238,8 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-        private void RaisePropertyChanged(
-            [CallerMemberName]string propertyName = "")
-        {
-            var threadSafeCall = PropertyChanged;
-
-            threadSafeCall?.Invoke(
-                this,
-                new PropertyChangedEventArgs(
-                    propertyName));
-        }
-
         #region View Disappearing event
+
         private async void OnContentUnloaded(
             object sender,
             EventArgs eventArgs)
@@ -273,7 +280,8 @@ namespace CodeMonkeys.Navigation.WPF
 
             content.Unloaded -= OnContentUnloaded;
         }
-        #endregion
+
+        #endregion View Disappearing event
 
 
 

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
@@ -50,10 +50,10 @@ namespace CodeMonkeys.Navigation.WPF
 
         public bool TryGoBack()
         {
-            if (!CanGoBack())
+            if (!CanGoBack)
                 return false;
 
-            
+
             var destination = BackStack.LastOrDefault();
 
             if (destination == null)
@@ -77,7 +77,7 @@ namespace CodeMonkeys.Navigation.WPF
 
         public bool TryGoForward()
         {
-            if (!CanGoForward())
+            if (!CanGoForward)
                 return false;
 
 
@@ -256,6 +256,13 @@ namespace CodeMonkeys.Navigation.WPF
             Current = new NavigationStackEntry(
                 viewModel,
                 content);
+
+
+            RaisePropertyChanged(
+                nameof(CanGoBack));
+
+            RaisePropertyChanged(
+                nameof(CanGoForward));
         }
 
 


### PR DESCRIPTION
changed CanGoBack and CanGoForward to properties instead of methods and raise PropertyChanged on current page change