### PR TITLE
Merge Bugfix/removed-old-navigationservice-reference into develop

### DIFF
--- a/samples/ViewModels/MainViewModel.cs
+++ b/samples/ViewModels/MainViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using CodeMonkeys.MVVM.Attributes;
 using CodeMonkeys.MVVM.Commands;
 using CodeMonkeys.MVVM.PropertyChanged;
-
 using CodeMonkeys.Navigation.WPF;
+
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -29,13 +29,9 @@ namespace CodeMonkeys.Samples.ViewModels
         public ICommand NavigateBackCommand { get; }
         public ICommand NavigateForwardCommand { get; }
 
-        public MainViewModel(
-            INavigationService navigationService)
+        public MainViewModel()
         {
-            NavigationService = navigationService;
-
             MenuItems = new ObservableCollection<MenuItem>();
-
 
 
             NavigateBackCommand = new Command(
@@ -44,6 +40,13 @@ namespace CodeMonkeys.Samples.ViewModels
             NavigateForwardCommand = new Command(
                 () => NavigationService.TryGoForward());
         }
+
+        //public MainViewModel(
+        //    INavigationService navigationService)
+        //    : this()
+        //{
+        //    NavigationService = navigationService;
+        //}
 
         public override async Task InitializeAsync()
         {

--- a/samples/Xamarin.Forms/MasterDetail/MasterDetailSample/MasterDetailSample/App.xaml.cs
+++ b/samples/Xamarin.Forms/MasterDetail/MasterDetailSample/MasterDetailSample/App.xaml.cs
@@ -40,7 +40,7 @@ namespace MasterDetailSample
             navigationService.Register<AboutViewModel, AboutPage>();
             navigationService.Register<ItemDetailsViewModel, ItemDetailsPage>();
 
-            await navigationService.SetRoot<MainViewModel, ItemsViewModel>();
+            await navigationService.SetRootAsync<MainViewModel, ItemsViewModel>();
         }
 
         protected override void OnSleep()

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>    
     <AssemblyName>CodeMonkeys.Core</AssemblyName>
     <RootNamespace>CodeMonkeys</RootNamespace>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>

--- a/src/Core/MVVM/IViewModel.cs
+++ b/src/Core/MVVM/IViewModel.cs
@@ -5,12 +5,12 @@ namespace CodeMonkeys.MVVM
     public interface IViewModel
     {
         /// <summary>
-        /// A flag indicating whether this viewmodel has been initialized using the <see cref="CodeMonkeys.Core.Interfaces.MVVM.IViewModel.InitializeAsync" /> method
+        /// A flag indicating whether this viewmodel has been initialized using the <see cref="CodeMonkeys.MVVM.IViewModel.InitializeAsync" /> method
         /// </summary>
         bool IsInitialized { get; }
 
         /// <summary>
-        /// Method that automatically gets called when the instance was built using the ViewModelFactory or the <see cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService" />
+        /// Method that automatically gets called when the instance was built using the ViewModelFactory or the <see cref="CodeMonkeys.Navigation.INavigationService" />
         /// </summary>
         Task InitializeAsync();
     }

--- a/src/Core/MVVM/IViewModelT.cs
+++ b/src/Core/MVVM/IViewModelT.cs
@@ -6,7 +6,7 @@ namespace CodeMonkeys.MVVM
         IViewModel
     {
         /// <summary>
-        /// Method that automatically gets called when the instance was built using the ViewModelFactory or the <see cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService" />
+        /// Method that automatically gets called when the instance was built using the ViewModelFactory or the <see cref="CodeMonkeys.Navigation.INavigationService" />
         /// </summary>
         /// <param name="model">Data that should be used for initialization</param>
         Task InitializeAsync(TModel model);

--- a/src/MVVM/MVVM.csproj
+++ b/src/MVVM/MVVM.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>CodeMonkeys.MVVM</AssemblyName>
     <RootNamespace>CodeMonkeys.MVVM</RootNamespace>    
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>

--- a/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBase.cs
@@ -16,7 +16,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
 
 
         /// <summary>
-        /// Invokes the IViewModelNavigationService (if registered) to show the requested ViewModel
+        /// Invokes the <see cref="CodeMonkeys.Navigation.INavigationService"/> (if registered) to show the requested ViewModel
         /// </summary>
         /// <typeparam name="TDestination">Type of the ViewModel interface to show</typeparam>
         public async Task ShowAsync<TDestination>()
@@ -28,7 +28,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
         }
 
         /// <summary>
-        /// Invokes the IViewModelNavigationService (if registered) to show the requested ViewModel
+        /// Invokes the <see cref="CodeMonkeys.Navigation.INavigationService"/> (if registered) to show the requested ViewModel
         /// Passes the parameter for the ViewModel initialization
         /// </summary>
         /// <typeparam name="TDestination">Type of the ViewModel interface to show</typeparam>
@@ -45,7 +45,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
         }
 
         /// <summary>
-        /// Closes this ViewModel using the IViewModelNavigationService (if registered)
+        /// Closes this ViewModel using the <see cref="CodeMonkeys.Navigation.INavigationService"/> (if registered)
         /// </summary>
         public virtual async Task CloseAsync()
         {
@@ -58,7 +58,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
         }
 
         /// <summary>
-        /// Closes this ViewModel and informs the parent using the IViewModelNavigationService (if registered)
+        /// Closes this ViewModel and informs the parent using the <see cref="CodeMonkeys.Navigation.INavigationService"/> (if registered)
         /// </summary>
         /// <typeparam name="TParentViewModelInterface">Type of the parent ViewModel to inform</typeparam>
         public virtual async Task CloseAsync<TParentViewModelInterface>()
@@ -75,7 +75,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
         }
 
         /// <summary>
-        /// Closes this ViewModel and informs the parent using the IViewModelNavigationService (if registered)
+        /// Closes this ViewModel and informs the parent using the <see cref="CodeMonkeys.Navigation.INavigationService"/> (if registered)
         /// </summary>
         /// <typeparam name="TParentViewModelInterface">Type of the parent ViewModel to inform</typeparam>
         /// <typeparam name="TResult">Type of the result data</typeparam>

--- a/src/MVVM/ViewModels/Navigation/ViewModelBaseHelper.cs
+++ b/src/MVVM/ViewModels/Navigation/ViewModelBaseHelper.cs
@@ -36,6 +36,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
             this ViewModelBase<TInterface> viewModelBase,
             int parametersCount = 1,
             int genericArgumentsCount = 2)
+
             where TInterface : IViewModel
         {
             var closeAsyncTask = GetCloseAsyncMethodInfos(viewModelBase)
@@ -58,6 +59,7 @@ namespace CodeMonkeys.MVVM.ViewModels.Navigation
             this ViewModelBase<TInterface, TModel> viewModelBase,
             int parametersCount = 1,
             int genericArgumentsCount = 2)
+
             where TInterface : IViewModel<TModel>
         {
             var closeAsyncTask = GetCloseAsyncMethodInfos(viewModelBase)

--- a/src/Navigation/WPF/Navigation.WPF.Interfaces/INavigationService.cs
+++ b/src/Navigation/WPF/Navigation.WPF.Interfaces/INavigationService.cs
@@ -8,7 +8,14 @@ namespace CodeMonkeys.Navigation.WPF
         CodeMonkeys.Navigation.INavigationService
     {
         IViewModel RootViewModel { get; }
+
         IViewModel CurrentViewModel { get; }
+
+
+        bool CanGoBack { get; }
+
+        bool CanGoForward { get; }
+
 
 
         Task SetRootWindowAsync<TRootViewModel>()
@@ -19,16 +26,16 @@ namespace CodeMonkeys.Navigation.WPF
             where TInitialViewModel : class, IViewModel;
 
 
-        bool CanGoBack();
-        bool CanGoForward();
-
         bool TryGoBack();
+
         bool TryGoForward();
 
 
 
         void ClearStacks();
+
         void ClearBackStack();
+
         void ClearForwardStack();
     }
 }

--- a/src/Navigation/WPF/Navigation.WPF.Interfaces/Navigation.WPF.Interfaces.csproj
+++ b/src/Navigation/WPF/Navigation.WPF.Interfaces/Navigation.WPF.Interfaces.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>CodeMonkeys.Navigation.WPF.Interfaces</AssemblyName>
     <RootNamespace>CodeMonkeys.Navigation</RootNamespace>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>

--- a/src/Navigation/WPF/Navigation.WPF/Navigation.WPF.csproj
+++ b/src/Navigation/WPF/Navigation.WPF/Navigation.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,7 +6,7 @@
     <AssemblyName>CodeMonkeys.Navigation.WPF</AssemblyName>
     <RootNamespace>CodeMonkeys.Navigation.WPF</RootNamespace>
     <Authors>Jan Morfeld &amp; Daniel Belz</Authors>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Company>UltimateCodeMonkeys</Company>
     <Product>CodeMonkeysMVVM</Product>
     <Description>Package to use ViewModel navigation in WPF MVVM application</Description>
@@ -35,5 +35,4 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
@@ -63,11 +63,11 @@ namespace CodeMonkeys.Navigation.WPF
                 return Task.CompletedTask;
 
 
+            ClearStacks();
+
             SetCurrent(
                 Root.ViewModel,
                 Root.Content);
-
-            ClearStacks();
 
 
             return Task.CompletedTask;

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
@@ -8,7 +8,7 @@ namespace CodeMonkeys.Navigation.WPF
 {
     public partial class NavigationService
     {
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface}" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.CloseAsync{TViewModelInterface}" />
         public virtual Task CloseAsync<TViewModel>()
 
             where TViewModel : class, IViewModel
@@ -22,7 +22,7 @@ namespace CodeMonkeys.Navigation.WPF
             return Task.CompletedTask;
         }
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface}" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface}" />
         public virtual async Task CloseAsync<TViewModel, TParentViewModel>()
 
             where TViewModel : class, IViewModel
@@ -38,7 +38,7 @@ namespace CodeMonkeys.Navigation.WPF
             await ResolveAndInformParent<TParentViewModel>();
         }
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface, TResult}(TResult)" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface, TResult}(TResult)" />
         public virtual async Task CloseAsync<TViewModelInterface, TParentViewModelInterface, TResult>(
             TResult result)
 

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
@@ -36,11 +36,13 @@ namespace CodeMonkeys.Navigation.WPF
 
 
         protected IList<NavigationStackEntry> BackStack { get; set; }
+
         protected IList<WeakNavigationStackEntry> ForwardStack { get; set; }
 
 
 
         private NavigationStackEntry root;
+
         protected NavigationStackEntry Root
         {
             get => root;
@@ -48,13 +50,14 @@ namespace CodeMonkeys.Navigation.WPF
             {
                 root = value;
                 RaisePropertyChanged();
-                
+
                 RaisePropertyChanged(nameof(CurrentViewModel));
                 RaisePropertyChanged(nameof(CurrentContent));
             }
         }
 
         private NavigationStackEntry current;
+
         protected NavigationStackEntry Current
         {
             get => current;
@@ -80,7 +83,14 @@ namespace CodeMonkeys.Navigation.WPF
 
 
         public IViewModel RootViewModel => Root?.ViewModel;
+
         public IViewModel CurrentViewModel => Current?.ViewModel;
+
+
+        public bool CanGoBack => BackStack?.Any() == true;
+
+        public bool CanGoForward => IsForwardNavigationPossible();
+
 
         public FrameworkElement CurrentContent => Current?.Content;
 
@@ -137,24 +147,6 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-        public bool CanGoBack()
-        {
-            return BackStack.Any();
-        }
-
-        public bool CanGoForward()
-        {
-            var target = ForwardStack.LastOrDefault();
-
-            if (target == null)
-                return false;
-
-
-            return target.Content?.TryGetTarget(out _) == true &&
-                target.ViewModel?.TryGetTarget(out _) == true;
-        }
-
-
         public void ClearStacks()
         {
             ClearBackStack();
@@ -190,7 +182,7 @@ namespace CodeMonkeys.Navigation.WPF
                 viewModel,
                 content);
 
-            
+
 
             SetCurrent(
                 viewModel,
@@ -198,6 +190,31 @@ namespace CodeMonkeys.Navigation.WPF
 
 
             return content;
+        }
+
+        protected void RaisePropertyChanged(
+            [CallerMemberName] string propertyName = "")
+        {
+            var threadSafeCall = PropertyChanged;
+
+            threadSafeCall?.Invoke(
+                this,
+                new PropertyChangedEventArgs(
+                    propertyName));
+        }
+
+
+
+        private bool IsForwardNavigationPossible()
+        {
+            var target = ForwardStack.LastOrDefault();
+
+            if (target == null)
+                return false;
+
+
+            return target.Content?.TryGetTarget(out _) == true &&
+                target.ViewModel?.TryGetTarget(out _) == true;
         }
 
 
@@ -221,18 +238,8 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-        private void RaisePropertyChanged(
-            [CallerMemberName]string propertyName = "")
-        {
-            var threadSafeCall = PropertyChanged;
-
-            threadSafeCall?.Invoke(
-                this,
-                new PropertyChangedEventArgs(
-                    propertyName));
-        }
-
         #region View Disappearing event
+
         private async void OnContentUnloaded(
             object sender,
             EventArgs eventArgs)
@@ -273,7 +280,8 @@ namespace CodeMonkeys.Navigation.WPF
 
             content.Unloaded -= OnContentUnloaded;
         }
-        #endregion
+
+        #endregion View Disappearing event
 
 
 

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
@@ -15,7 +15,7 @@ namespace CodeMonkeys.Navigation.WPF
             new List<INavigationRegistration>();
 
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.Register(INavigationRegistration)" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.Register(INavigationRegistration)" />
         public void Register(INavigationRegistration registration)
         {
             RegisterInternal(registration);

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
@@ -50,10 +50,10 @@ namespace CodeMonkeys.Navigation.WPF
 
         public bool TryGoBack()
         {
-            if (!CanGoBack())
+            if (!CanGoBack)
                 return false;
 
-            
+
             var destination = BackStack.LastOrDefault();
 
             if (destination == null)
@@ -77,7 +77,7 @@ namespace CodeMonkeys.Navigation.WPF
 
         public bool TryGoForward()
         {
-            if (!CanGoForward())
+            if (!CanGoForward)
                 return false;
 
 
@@ -256,6 +256,13 @@ namespace CodeMonkeys.Navigation.WPF
             Current = new NavigationStackEntry(
                 viewModel,
                 content);
+
+
+            RaisePropertyChanged(
+                nameof(CanGoBack));
+
+            RaisePropertyChanged(
+                nameof(CanGoForward));
         }
 
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms.Interfaces/INavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms.Interfaces/INavigationService.cs
@@ -13,7 +13,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         /// <typeparam name="TMasterViewModel">Master ViewModel containing the menu information</typeparam>
         /// <typeparam name="TDetailViewModel">Detail ViewModel to show on start</typeparam>
         /// <returns><see cref="Task" /> to await on</returns>
-        Task SetRoot<TMasterViewModel, TDetailViewModel>()
+        Task SetRootAsync<TMasterViewModel, TDetailViewModel>()
             where TMasterViewModel : class, IViewModel
             where TDetailViewModel : class, IViewModel;
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cache.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cache.cs
@@ -14,7 +14,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         private static readonly IList<CachedPage> PageCache =
             new List<CachedPage>();
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.ClearCache" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.ClearCache" />
         public void ClearCache()
         {
             Log?.Info(

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
@@ -40,25 +40,13 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
                 }
 
 
-                switch (Application.Current.MainPage)
+                rootPage = Application.Current.MainPage switch
                 {
-                    case NavigationPage navigationPage:
-                        rootPage = navigationPage.RootPage;
-                        break;
-
-                    case TabbedPage tabbedPage:
-                        rootPage = tabbedPage;
-                        break;
-
-                    case MasterDetailPage masterDetailPage:
-                        rootPage = masterDetailPage;
-                        break;
-
-                    default:
-                        rootPage = Application.Current.MainPage;
-                        break;
-                }
-
+                    NavigationPage navigationPage => navigationPage.RootPage,
+                    TabbedPage tabbedPage => tabbedPage,
+                    MasterDetailPage masterDetailPage => masterDetailPage,
+                    _ => Application.Current.MainPage,
+                };
 
                 return rootPage;
             }
@@ -68,17 +56,12 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         {
             get
             {
-                switch (RootPage)
+                return RootPage switch
                 {
-                    case MasterDetailPage masterDetail:
-                        return masterDetail.Detail.Navigation;
-
-                    case TabbedPage tabbed:
-                        return tabbed.Navigation;
-
-                    default:
-                        return RootPage.Navigation;
-                }
+                    MasterDetailPage masterDetail => masterDetail.Detail.Navigation,
+                    TabbedPage tabbed => tabbed.Navigation,
+                    _ => RootPage.Navigation,
+                };
             }
         }
 
@@ -111,7 +94,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.SetRoot{TViewModelInterface}()" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.SetRoot{TViewModelInterface}()" />
         public async Task SetRootAsync<TViewModel>()
 
             where TViewModel : class, IViewModel
@@ -128,7 +111,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             SetRootInternal(page);
         }
 
-        public async Task SetRoot<TMasterViewModel, TDetailViewModel>()
+        public async Task SetRootAsync<TMasterViewModel, TDetailViewModel>()
 
             where TMasterViewModel : class, IViewModel
             where TDetailViewModel : class, IViewModel

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
@@ -16,7 +16,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             new List<INavigationRegistration>();
 
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.Register(INavigationRegistration)" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.Register(INavigationRegistration)" />
         public void Register(
             INavigationRegistration registrationInfo)
         {
@@ -65,7 +65,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
 
-        /// <inheritdoc cref="CodeMonkeys.Core.Interfaces.Navigation.IViewModelNavigationService.Unregister{TViewModelInterface}" />
+        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.Unregister{TViewModelInterface}" />
         public void Unregister<TViewModel>()
 
             where TViewModel : class, IViewModel
@@ -170,26 +170,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             return registrationInfo != null;
         }
-
-        private static bool TryGetRegistration(
-            Type viewModelInterfaceType,
-            DevicePlatforms platform,
-            out INavigationRegistration registrationInfo)
-        {
-            if (!IsRegistered(viewModelInterfaceType))
-            {
-                registrationInfo = null;
-                return false;
-            }
-
-
-            registrationInfo = NavigationRegistrations.OfType<NavigationRegistration>()
-                .FirstOrDefault(registration =>
-                    registration.ViewModelType == viewModelInterfaceType &&
-                    registration.Platform == platform);
-
-            return registrationInfo != null;
-        }
+                
 
         private static bool TryGetRegistration(
             Type viewModelType,

--- a/src/tests/UnitTests/Navigation/WPF/NavigationServiceTests.show.cs
+++ b/src/tests/UnitTests/Navigation/WPF/NavigationServiceTests.show.cs
@@ -112,7 +112,7 @@ namespace CodeMonkeys.UnitTests.Navigation.WPF
         [Test]
         public void CanGoBack_WhenBackStackIsEmpty_ReturnsFalse()
         {
-            bool canNavigateBackwards = navigationService.CanGoBack();
+            bool canNavigateBackwards = navigationService.CanGoBack;
 
 
             Assert.IsFalse(canNavigateBackwards);
@@ -127,7 +127,7 @@ namespace CodeMonkeys.UnitTests.Navigation.WPF
             await navigationService.ShowAsync<SecondViewModel>();
 
 
-            bool canNavigateBackwards = navigationService.CanGoBack();
+            bool canNavigateBackwards = navigationService.CanGoBack;
 
 
             Assert.IsTrue(canNavigateBackwards);
@@ -137,7 +137,7 @@ namespace CodeMonkeys.UnitTests.Navigation.WPF
         [Test]
         public void CanGoForward_WhenForwardStackIsEmpty_ReturnsFalse()
         {
-            bool canNavigateBackwards = navigationService.CanGoForward();
+            bool canNavigateBackwards = navigationService.CanGoForward;
 
 
             Assert.IsFalse(canNavigateBackwards);
@@ -153,7 +153,7 @@ namespace CodeMonkeys.UnitTests.Navigation.WPF
             navigationService.TryGoBack();
 
 
-            bool canNavigateForward = navigationService.CanGoForward();
+            bool canNavigateForward = navigationService.CanGoForward;
 
 
             Assert.True(canNavigateForward);


### PR DESCRIPTION
Removed old `IViewModelNavigationService` reference from XML comments and renamed `SetRoot` to `SetRootAsync`