### PR TITLE
bugfix by changing firstordefault to foreach loop

### DIFF
--- a/samples/ViewModels/NestedViewModel.cs
+++ b/samples/ViewModels/NestedViewModel.cs
@@ -1,0 +1,14 @@
+﻿using CodeMonkeys.MVVM.ViewModels;
+
+namespace CodeMonkeys.Samples.ViewModels
+{
+    public class NestedViewModel :
+        ViewModelBase
+    {
+        public string Title
+        {
+            get => GetValue<string>();
+            set => SetValue(value);
+        }
+    }
+}

--- a/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
+++ b/src/MVVM/PropertyChanged/BindingBase/BindingBase.propertyChanged.cs
@@ -179,23 +179,24 @@ namespace CodeMonkeys.MVVM.PropertyChanged
         {
             var classType = GetType();
 
-            var dependencyRegistration = propertyDependencies.
-                FirstOrDefault(dependency =>
+            foreach (var dependencyRegistration in propertyDependencies.Where(
+                dependency =>
                     dependency.Class == classType &&
-                    dependency.Dependencies.Contains(propertyName));
-
-            if (dependencyRegistration == null)
+                    dependency.Dependencies.Contains(propertyName)))
             {
-                return;
+                if (dependencyRegistration == null)
+                {
+                    continue;
+                }
+
+
+                var threadSaveCall = PropertyChanged;
+
+                threadSaveCall?.Invoke(
+                    this,
+                    new PropertyChangedEventArgs(
+                        dependencyRegistration.PropertyName));
             }
-
-
-            var threadSaveCall = PropertyChanged;
-
-            threadSaveCall?.Invoke(
-                this,
-                new PropertyChangedEventArgs(
-                    dependencyRegistration.PropertyName));
         }
 
         private IEnumerable<PropertyInfo> GetCommandProperties()


### PR DESCRIPTION
## Proposed changes
Fixed a bug where `DependsOn` was only working for the first property it has been set on.
Further properties where ignored when raising `PropertyChanged` because the implementation was just calling `FirstOrDefault` on all matching registrations rather then looping through them.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


Closes #161 