### PR TITLE
Merge bugfix/navigation-registration-condition-not-used into develop

### DIFF
--- a/samples/Xamarin.Forms/TabbedSample/TabbedSample/App.xaml.cs
+++ b/samples/Xamarin.Forms/TabbedSample/TabbedSample/App.xaml.cs
@@ -1,5 +1,4 @@
-﻿using CodeMonkeys.MVVM;
-using CodeMonkeys.Navigation.Xamarin.Forms;
+﻿using CodeMonkeys.Navigation.Xamarin.Forms;
 using CodeMonkeys.Samples.ViewModels;
 
 using TabbedSample.Views;
@@ -18,10 +17,16 @@ namespace TabbedSample
 
         protected override async void OnStart()
         {
-            var dependencyContainer = CodeMonkeys.DependencyInjection.DryIoC.DryFactory.CreateInstance();
+            var dependencyContainer = CodeMonkeys.DependencyInjection.Ninject.NinjectFactory.CreateInstance();
 
-            dependencyContainer.RegisterType<CodeMonkeys.Navigation.INavigationService, NavigationService>();
-            dependencyContainer.RegisterType<CodeMonkeys.Navigation.Xamarin.Forms.INavigationService, NavigationService>();
+            //dependencyContainer.RegisterType<CodeMonkeys.Navigation.INavigationService, NavigationService>();
+            //dependencyContainer.RegisterType<INavigationService, NavigationService>();
+
+            var navigationService = new NavigationService(
+                dependencyContainer);
+
+            dependencyContainer.RegisterInstance<INavigationService>(navigationService);
+            dependencyContainer.RegisterInstance<CodeMonkeys.Navigation.INavigationService>(navigationService);
 
 
             dependencyContainer.RegisterType<MainViewModel>();
@@ -31,20 +36,30 @@ namespace TabbedSample
             dependencyContainer.RegisterType<ItemViewModel>();
             dependencyContainer.RegisterType<ItemDetailsViewModel>();
 
+            
 
-            ViewModelFactory.Configure(dependencyContainer);
+            try
+            {
+                navigationService.Register<MainViewModel, MainPage>();
 
-            var navigationService = dependencyContainer.Resolve<CodeMonkeys.Navigation.Xamarin.Forms.INavigationService>();
+                navigationService.Register<ItemsViewModel, ItemsPage>();
+                navigationService.Register<AboutViewModel, AboutPage>();
+
+                navigationService.Register<ItemDetailsViewModel, ItemDetailsPage>();
+
+                CodeMonkeys.MVVM.ViewModelFactory.Configure(
+                    dependencyContainer);
+
+                await navigationService.SetRootAsync<MainViewModel>();
+
+            }
+            catch (System.Exception ex)
+            {
+
+            }
 
 
-            navigationService.Register<MainViewModel, MainPage>();
-
-            navigationService.Register<ItemsViewModel, ItemsPage>();
-            navigationService.Register<AboutViewModel, AboutPage>();
-
-            navigationService.Register<ItemDetailsViewModel, ItemDetailsPage>();
-
-            await navigationService.SetRootAsync<MainViewModel>();
+            
         }
 
         protected override void OnSleep()

--- a/samples/Xamarin.Forms/TabbedSample/TabbedSample/TabbedSample.csproj
+++ b/samples/Xamarin.Forms/TabbedSample/TabbedSample/TabbedSample.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Core\Core.csproj" />
-    <ProjectReference Include="..\..\..\..\src\DependencyInjection\DependencyInjection.DryIoC\DependencyInjection.DryIoC.csproj" />
+    <ProjectReference Include="..\..\..\..\src\DependencyInjection\DependencyInjection.Ninject\DependencyInjection.Ninject.csproj" />
     <ProjectReference Include="..\..\..\..\src\DependencyInjection\DependencyInjection\DependencyInjection.csproj" />
     <ProjectReference Include="..\..\..\..\src\MVVM\MVVM.csproj" />
     <ProjectReference Include="..\..\..\..\src\Navigation\Navigation\Navigation.csproj" />


### PR DESCRIPTION
The `Condition` property from the `INavigationRegistration` interface was not used to check whether a View/ViewModel can be displayed or not.