### PR TITLE
Merge bugfix/invalid-log-file-name into develop

### DIFF
--- a/src/Logging/Logging.Batching/BatchLogOptions.cs
+++ b/src/Logging/Logging.Batching/BatchLogOptions.cs
@@ -6,7 +6,6 @@ namespace CodeMonkeys.Logging.Batching
     {
         private const int DEFAULT_FLUSHPERIOD = 5;
         private const int DEFAULT_BATCHCAPACITY = 50;
-        private const int DEFAULT_QUEUECAPACITY = 1000;
 
         /// <summary>
         /// The period after which log messages will be flushed to the store.
@@ -25,22 +24,6 @@ namespace CodeMonkeys.Logging.Batching
         public int? BatchCapacity
         {
             get => GetValue<int?>(DEFAULT_BATCHCAPACITY);
-            set
-            {
-                if (value != null)
-                    Property.GreaterThan(value.Value, 0);
-
-                SetValue(value);
-            }
-        }
-
-        /// <summary>
-        /// The maximum number of items in the background queue or <see langword="null"/> for no limit.
-        /// <para>Default value: <c>1000</c>.</para>
-        /// </summary>
-        public int? QueueCapacity
-        {
-            get => GetValue<int?>(DEFAULT_QUEUECAPACITY);
             set
             {
                 if (value != null)

--- a/src/Logging/Logging.File/FileLogOptions.cs
+++ b/src/Logging/Logging.File/FileLogOptions.cs
@@ -6,7 +6,7 @@ namespace CodeMonkeys.Logging.File
 {
     public class FileLogOptions : BatchLogOptions
     {
-        private readonly string DEFAULT_FILENAMEPREFIX = $"log-{DateTime.Now.ToShortDateString()}";
+        private readonly string DEFAULT_FILENAMEPREFIX = $"log-{DateTime.Now.Day}-{DateTime.Now.Month}-{DateTime.Now.Day}";
         private const string DEFAULT_EXTENSION = "txt";
 
         /// <summary>

--- a/src/Logging/Logging.File/FileLogService.cs
+++ b/src/Logging/Logging.File/FileLogService.cs
@@ -22,7 +22,7 @@ namespace CodeMonkeys.Logging.File
 
         protected override async Task PublishMessageBatch(IEnumerable<LogMessage> messageBatch)
         {
-            var directory = Directory.CreateDirectory(Options.Directory);
+            var directory = Directory.CreateDirectory(Options.Directory);            
 
             if (!directory.Exists)
             {


### PR DESCRIPTION
Closes #184 

Tagged as breaking change because the Option QueueCapacity was removed from the BatchLogOptions class