### PR TITLE
Merge feature/xamarin/inform interested viewmodel about closing into develop

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -31,10 +31,6 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Navigation\" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Core/Navigation/INavigationRegistration.cs
+++ b/src/Core/Navigation/INavigationRegistration.cs
@@ -8,6 +8,9 @@ namespace CodeMonkeys.Navigation
         Type ViewType { get; }
 
 
+        Type InterestedType { get; }
+
+
         /// <summary>
         /// <para>
         /// <see cref="CodeMonkeys.DependencyInjection.IDependencyContainer"/> is used to create the view if set to <value>true</value>.

--- a/src/Core/Navigation/INavigationService.cs
+++ b/src/Core/Navigation/INavigationService.cs
@@ -62,22 +62,6 @@ namespace CodeMonkeys.Navigation
         Task CloseAsync<TViewModel>()
             where TViewModel : class, IViewModel;
 
-        /// <summary>
-        /// Closes the View that is associated with the ViewModel interface type and informs the parent one
-        /// </summary>
-        Task CloseAsync<TViewModel, TInterestedViewModel>()
-            where TViewModel : class, IViewModel
-            where TInterestedViewModel : class, IViewModel, IListenToChildViewModelClosing;
-        
-        /// <summary>
-        /// Closes the View that is associated with the ViewModel interface type and informs the parent one
-        /// </summary>
-        /// <param name="resultData">The data that should be passed back to the parent (OnChildViewModelClosed)</param>
-        Task CloseAsync<TViewModel, TInterestedViewModel, TResult>(
-            TResult resultData)
-            where TViewModel : class, IViewModel
-            where TInterestedViewModel : class, IViewModel, IListenToChildViewModelClosing<TResult>;
-
 
         /// <summary>
         /// Clears the view instance cache.

--- a/src/Core/Navigation/ViewModels/IInterestedInClosing.cs
+++ b/src/Core/Navigation/ViewModels/IInterestedInClosing.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace CodeMonkeys.Navigation.ViewModels
+{
+    public interface IInterestedInClosing
+    {
+        Task OnInterestedViewModelClosingAsync();
+    }
+}

--- a/src/Core/Navigation/ViewModels/IInterestedInClosingT.cs
+++ b/src/Core/Navigation/ViewModels/IInterestedInClosingT.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace CodeMonkeys.Navigation.ViewModels
-{
-    public interface IInterestedInClosing<TResult>
-    {
-        Task OnInterestedViewModelClosingAsync(TResult result);
-    }
-}

--- a/src/Core/Navigation/ViewModels/IInterestedInClosingT.cs
+++ b/src/Core/Navigation/ViewModels/IInterestedInClosingT.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace CodeMonkeys.Navigation.ViewModels
+{
+    public interface IInterestedInClosing<TResult>
+    {
+        Task OnInterestedViewModelClosingAsync(TResult result);
+    }
+}

--- a/src/Core/Navigation/ViewModels/IListenToChildViewModelClosing.cs
+++ b/src/Core/Navigation/ViewModels/IListenToChildViewModelClosing.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace CodeMonkeys.Navigation.ViewModels
-{
-    public interface IListenToChildViewModelClosing
-    {
-        Task OnChildViewModelClosingAsync();
-    }
-}

--- a/src/Core/Navigation/ViewModels/IListenToChildViewModelClosingT.cs
+++ b/src/Core/Navigation/ViewModels/IListenToChildViewModelClosingT.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace CodeMonkeys.Navigation.ViewModels
-{
-    public interface IListenToChildViewModelClosing<TResult>
-    {
-        Task OnChildViewModelClosingAsync(TResult result);
-    }
-}

--- a/src/DependencyInjection/DependencyInjection.DryIoC/DryContainer.cs
+++ b/src/DependencyInjection/DependencyInjection.DryIoC/DryContainer.cs
@@ -40,7 +40,9 @@ namespace CodeMonkeys.DependencyInjection.DryIoC
 
 
             if (!(instance is TImplementation implementation))
+            {
                 return null;
+            }
 
 
             return implementation;

--- a/src/DependencyInjection/DependencyInjection.Ninject/NinjectContainer.cs
+++ b/src/DependencyInjection/DependencyInjection.Ninject/NinjectContainer.cs
@@ -56,7 +56,9 @@ namespace CodeMonkeys.DependencyInjection.Ninject
             var instance = container.Get(serviceType);
 
             if (!(instance is TImplementation implementation))
+            {
                 return null;
+            }
 
 
             return implementation;

--- a/src/MVVM/ViewModelFactory/ViewModelFactory.cs
+++ b/src/MVVM/ViewModelFactory/ViewModelFactory.cs
@@ -16,9 +16,7 @@ namespace CodeMonkeys.MVVM
         private static ILogService log;
         private static IDependencyContainer container;
 
-        private static INavigationService navigationServiceInstance;
-
-        private const string ARGUMENT_NULL_EXCEPTION_MESSAGE = "ViewModel cannot be resolved --- is it registered?";
+        private const string ARGUMENT_NULL_EXCEPTION_MESSAGE = "No ViewModel type has been provided!";
 
         /// <summary>
         /// Sets up the factory for further usage by passing the DI container instance and an optional logger
@@ -32,29 +30,6 @@ namespace CodeMonkeys.MVVM
             container = typeResolver;
             log = logService;
         }
-
-
-        internal static INavigationService TryResolveNavigationServiceInstance()
-        {
-            try
-            {
-                return navigationServiceInstance ??= container.Resolve<INavigationService>();
-            }
-            catch (Exception innerException)
-            {
-                string errorMessage =
-                    $"Unable to resolve instance of type {typeof(INavigationService)} --- did you register an implementation?";
-
-                log?.Error(
-                    errorMessage,
-                    innerException);
-
-                throw new TypeLoadException(
-                    errorMessage,
-                    innerException);
-            }
-        }
-
 
         /// <summary>
         /// Creates a new ViewModel instance, invokes the InitializeAsync method and returns the initialized instance
@@ -84,14 +59,16 @@ namespace CodeMonkeys.MVVM
                                     registration.ViewModel == viewModelType);
 
                 if (registration != null &&
-                    registration.Initialize)
+                    registration.Initialize &&
+                    instance != null)
                 {
                     TaskHelper.RunSync(instance.InitializeAsync);
                 }
 
+
                 return instance;
             }
-            catch (Exception innerException)
+            catch (Exception exception)
             {
                 string errorMessage = viewModelType == null ?
                     ARGUMENT_NULL_EXCEPTION_MESSAGE :
@@ -99,11 +76,10 @@ namespace CodeMonkeys.MVVM
 
                 log?.Critical(
                     errorMessage,
-                    innerException);
+                    exception);
 
-                throw new TypeLoadException(
-                    errorMessage,
-                    innerException);
+
+                throw;
             }
         }
 
@@ -139,14 +115,15 @@ namespace CodeMonkeys.MVVM
                                     registration.ViewModel == viewModelType);
 
                 if (registration != null &&
-                    registration.Initialize)
+                    registration.Initialize &&
+                    instance != null)
                 {
                     await instance.InitializeAsync();
                 }
 
                 return instance;
             }
-            catch (Exception innerException)
+            catch (Exception exception)
             {
                 string errorMessage = viewModelType == null ?
                     ARGUMENT_NULL_EXCEPTION_MESSAGE :
@@ -154,11 +131,9 @@ namespace CodeMonkeys.MVVM
 
                 log?.Critical(
                     errorMessage,
-                    innerException);
+                    exception);
 
-                throw new TypeLoadException(
-                    errorMessage,
-                    innerException);
+                throw;
             }
         }
 
@@ -195,14 +170,16 @@ namespace CodeMonkeys.MVVM
                                     registration.ViewModel == viewModelType);
 
                 if (registration != null &&
-                    registration.Initialize)
+                    registration.Initialize && 
+                    instance != null)
                 {
                     TaskHelper.RunSync(() => instance.InitializeAsync(model));
                 }
 
+
                 return instance;
             }
-            catch (Exception innerException)
+            catch (Exception exception)
             {
                 string errorMessage = viewModelType == null ?
                     ARGUMENT_NULL_EXCEPTION_MESSAGE :
@@ -210,11 +187,10 @@ namespace CodeMonkeys.MVVM
 
                 log?.Critical(
                     errorMessage,
-                    innerException);
+                    exception);
 
-                throw new TypeLoadException(
-                    errorMessage,
-                    innerException);
+
+                throw;
             }
         }
 
@@ -255,15 +231,17 @@ namespace CodeMonkeys.MVVM
                                     registration.ViewModel == viewModelType);
 
                 if (registration != null &&
-                    registration.Initialize)
+                    registration.Initialize &&
+                    instance != null)
                 {
                     await instance.InitializeAsync(
                         model);
-                }                
+                }
+
 
                 return instance;
             }
-            catch (Exception innerException)
+            catch (Exception exception)
             {
                 string errorMessage = viewModelType == null ?
                     ARGUMENT_NULL_EXCEPTION_MESSAGE :
@@ -271,11 +249,10 @@ namespace CodeMonkeys.MVVM
 
                 log?.Critical(
                     errorMessage,
-                    innerException);
+                    exception);
 
-                throw new TypeLoadException(
-                    errorMessage,
-                    innerException);
+
+                throw;
             }
         }
 

--- a/src/Navigation/WPF/Navigation.WPF/Models/RegistrationInfo.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Models/RegistrationInfo.cs
@@ -10,6 +10,8 @@ namespace CodeMonkeys.Navigation.WPF
         public Type ViewType { get; set; }
 
 
+        public Type InterestedType { get; set; }
+
         public bool PreCreateInstance { get; set; }
 
 

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
@@ -26,7 +26,7 @@ namespace CodeMonkeys.Navigation.WPF
         public virtual async Task CloseAsync<TViewModel, TParentViewModel>()
 
             where TViewModel : class, IViewModel
-            where TParentViewModel : class, IViewModel, IListenToChildViewModelClosing
+            where TParentViewModel : class, IViewModel, IInterestedInClosing
         {
             ThrowIfNotRegistered<TViewModel>();
 
@@ -43,7 +43,7 @@ namespace CodeMonkeys.Navigation.WPF
             TResult result)
 
             where TViewModelInterface : class, IViewModel
-            where TParentViewModelInterface : class, IViewModel, IListenToChildViewModelClosing<TResult>
+            where TParentViewModelInterface : class, IViewModel, IInterestedInClosing<TResult>
         {
             ThrowIfNotRegistered<TViewModelInterface>();
 
@@ -77,27 +77,27 @@ namespace CodeMonkeys.Navigation.WPF
 
         private async Task ResolveAndInformParent<TParentViewModelInterface>()
 
-            where TParentViewModelInterface : class, IListenToChildViewModelClosing
+            where TParentViewModelInterface : class, IInterestedInClosing
         {
             var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
 
             Log?.Info(
                 $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
 
-            await parentViewModel.OnChildViewModelClosingAsync();
+            await parentViewModel.OnInterestedViewModelClosingAsync();
         }
 
         private async Task ResolveAndInformParent<TParentViewModelInterface, TResult>(
             TResult result)
 
-            where TParentViewModelInterface : class, IListenToChildViewModelClosing<TResult>
+            where TParentViewModelInterface : class, IInterestedInClosing<TResult>
         {
             var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
 
             Log?.Info(
                 $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
 
-            await parentViewModel.OnChildViewModelClosingAsync(
+            await parentViewModel.OnInterestedViewModelClosingAsync(
                 result);
         }
     }

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.close.cs
@@ -1,8 +1,11 @@
-﻿using CodeMonkeys.Logging;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+using CodeMonkeys.Logging;
 using CodeMonkeys.MVVM;
 using CodeMonkeys.Navigation.ViewModels;
-
-using System.Threading.Tasks;
 
 namespace CodeMonkeys.Navigation.WPF
 {
@@ -20,40 +23,6 @@ namespace CodeMonkeys.Navigation.WPF
 
 
             return Task.CompletedTask;
-        }
-
-        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface}" />
-        public virtual async Task CloseAsync<TViewModel, TParentViewModel>()
-
-            where TViewModel : class, IViewModel
-            where TParentViewModel : class, IViewModel, IInterestedInClosing
-        {
-            ThrowIfNotRegistered<TViewModel>();
-
-
-            if (!TryGoBack())
-                return;
-
-
-            await ResolveAndInformParent<TParentViewModel>();
-        }
-
-        /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.CloseAsync{TViewModelInterface, TParentViewModelInterface, TResult}(TResult)" />
-        public virtual async Task CloseAsync<TViewModelInterface, TParentViewModelInterface, TResult>(
-            TResult result)
-
-            where TViewModelInterface : class, IViewModel
-            where TParentViewModelInterface : class, IViewModel, IInterestedInClosing<TResult>
-        {
-            ThrowIfNotRegistered<TViewModelInterface>();
-
-
-            if (!TryGoBack())
-                return;
-
-
-            await ResolveAndInformParent<TParentViewModelInterface, TResult>(
-                result);
         }
 
 
@@ -74,31 +43,78 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-
-        private async Task ResolveAndInformParent<TParentViewModelInterface>()
-
-            where TParentViewModelInterface : class, IInterestedInClosing
+        private async Task ResolveAndInformListenerAsync(
+            Type listenerType)
         {
-            var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
+            if (listenerType == null)
+            {
+                return;
+            }
+
+
+            var listener = dependencyResolver.Resolve<IInterestedInClosing>(
+                listenerType);
+
 
             Log?.Info(
-                $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
+                $"ViewModelInstance for type {listener?.GetType().Name} has been resolved.");
 
-            await parentViewModel.OnInterestedViewModelClosingAsync();
+            
+            await listener?.OnInterestedViewModelClosingAsync();
         }
 
-        private async Task ResolveAndInformParent<TParentViewModelInterface, TResult>(
-            TResult result)
 
-            where TParentViewModelInterface : class, IInterestedInClosing<TResult>
+
+
+        #region View Disappearing event
+
+        private async void OnContentUnloaded(
+            object sender,
+            EventArgs eventArgs)
         {
-            var parentViewModel = dependencyResolver.Resolve<TParentViewModelInterface>();
+            if (!(sender is FrameworkElement content))
+            {
+                return;
+            }
 
-            Log?.Info(
-                $"ViewModelInstance for type {typeof(TParentViewModelInterface).Name} has been resolved.");
+            var registrationInfo = Registrations?.FirstOrDefault(
+                registration => registration.ViewType == content.GetType());
 
-            await parentViewModel.OnInterestedViewModelClosingAsync(
-                result);
+            if (registrationInfo == null)
+            {
+                DetachDisappearingEventListener(content);
+                return;
+            }
+
+
+            if (content.DataContext is IHandleClosing viewModel)
+            {
+                await viewModel.OnClosing();
+            }
+
+            if (registrationInfo.InterestedType != null)
+            {
+                await ResolveAndInformListenerAsync(
+                    registrationInfo.InterestedType)
+                    .ConfigureAwait(false);
+            }
+
+
+            DetachDisappearingEventListener(content);
         }
+
+
+        private void DetachDisappearingEventListener(
+            FrameworkElement content)
+        {
+            if (content == null)
+            {
+                return;
+            }
+
+            content.Unloaded -= OnContentUnloaded;
+        }
+
+        #endregion View Disappearing event
     }
 }

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.cs
@@ -238,53 +238,6 @@ namespace CodeMonkeys.Navigation.WPF
         }
 
 
-        #region View Disappearing event
-
-        private async void OnContentUnloaded(
-            object sender,
-            EventArgs eventArgs)
-        {
-            if (!(sender is FrameworkElement content))
-            {
-                return;
-            }
-
-            if (Registrations == null ||
-                !Registrations.Any(
-                    registration => registration.ViewType == content.GetType()))
-            {
-                DetachDisappearingEventListener(content);
-                return;
-            }
-
-
-            if (!(content.DataContext is IHandleClosing viewModel))
-            {
-                DetachDisappearingEventListener(content);
-                return;
-            }
-
-            await viewModel.OnClosing();
-
-            DetachDisappearingEventListener(content);
-        }
-
-
-        private void DetachDisappearingEventListener(
-            FrameworkElement content)
-        {
-            if (content == null)
-            {
-                return;
-            }
-
-            content.Unloaded -= OnContentUnloaded;
-        }
-
-        #endregion View Disappearing event
-
-
-
         public static void SetupLogging(
             ILogService logService)
         {

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.registration.cs
@@ -147,6 +147,7 @@ namespace CodeMonkeys.Navigation.WPF
                 .FirstOrDefault(registration =>
                     registration.ViewModelType == viewModelType);
 
+
             return registrationInfo != null;
         }
                 

--- a/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
+++ b/src/Navigation/WPF/Navigation.WPF/Service/NavigationService.show.cs
@@ -150,7 +150,8 @@ namespace CodeMonkeys.Navigation.WPF
             content.DataContext = viewModel;
 
 
-            if (viewModel is IHandleClosing)
+            if (viewModel is IHandleClosing ||
+                registration.InterestedType != null)
             {
                 content.Unloaded += OnContentUnloaded;
             }
@@ -158,6 +159,7 @@ namespace CodeMonkeys.Navigation.WPF
 
             Log?.Info(
                 $"View of type {content.GetType().Name} has been created!");
+
 
             return (TView)content;
         }

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Models/Registration/NavigationRegistration.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Models/Registration/NavigationRegistration.cs
@@ -9,6 +9,10 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         public virtual Type ViewType { get; internal set; }
 
 
+        public virtual Type InterestedType { get; internal set; }
+
+
+
         /// <inheritdoc cref="INavigationRegistration.ResolveViewUsingDependencyInjection" />
         public bool ResolveViewUsingDependencyInjection { get; set; }
         public bool PreCreateInstance { get; set; }

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Navigation.Xamarin.Forms.csproj
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Navigation.Xamarin.Forms.csproj
@@ -36,13 +36,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CodeMonkeys.Core" Version="2.1.8" />
-    <PackageReference Include="CodeMonkeys.Navigation.Xamarin.Forms.Interfaces" Version="2.1.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1560" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Core\Core.csproj" />
+    <ProjectReference Include="..\..\Navigation\Navigation.csproj" />
+    <ProjectReference Include="..\Navigation.Xamarin.Forms.Interfaces\Navigation.Xamarin.Forms.Interfaces.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/NavigationServiceExtensions.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/NavigationServiceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using CodeMonkeys.MVVM;
+using CodeMonkeys.Navigation.ViewModels;
 
 using System;
 
@@ -117,6 +118,18 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             return navigationService;
         }
 
+
+
+        public static NavigationRegistration WithInterestedViewModel<TInterested>(
+            this NavigationRegistration registrationInfo)
+
+            where TInterested : IInterestedInClosing
+        {
+            registrationInfo.InterestedType = typeof(TInterested);
+
+
+            return registrationInfo;
+        }
 
         /// <summary>
         /// States that the specific registration is only relevant for the given platform(s)

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/NavigationServiceExtensions.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/NavigationServiceExtensions.cs
@@ -120,7 +120,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
 
 
-        public static NavigationRegistration WithInterestedViewModel<TInterested>(
+        public static NavigationRegistration WithClosingListener<TInterested>(
             this NavigationRegistration registrationInfo)
 
             where TInterested : IInterestedInClosing

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.close.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.close.cs
@@ -31,10 +31,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             }
 
 
-            await ResolveAndInformListener(
-                registration.InterestedType);
-
-
             await CloseCurrentPage()
                 .ConfigureAwait(false);
         }
@@ -82,7 +78,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
 
-        private async Task ResolveAndInformListener(
+        private async Task ResolveAndInformListenerAsync(
             Type listenerType)
         {
             if (listenerType == null)
@@ -134,8 +130,9 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             if (registrationInfo.InterestedType != null)
             {
-                await ResolveAndInformListener(
-                    registrationInfo.InterestedType);
+                await ResolveAndInformListenerAsync(
+                    registrationInfo.InterestedType)
+                    .ConfigureAwait(false);
             }
 
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
@@ -1,14 +1,13 @@
-﻿using CodeMonkeys.DependencyInjection;
-using CodeMonkeys.Logging;
-using CodeMonkeys.MVVM;
-using CodeMonkeys.Navigation.ViewModels;
-using CodeMonkeys.Navigation.Xamarin.Forms.Pages;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using CodeMonkeys.DependencyInjection;
+using CodeMonkeys.Logging;
+using CodeMonkeys.MVVM;
+using CodeMonkeys.Navigation.Xamarin.Forms.Pages;
 
 using Xamarin.Forms;
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
@@ -206,6 +206,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
 
                 page.BindingContext = viewModel;
+                page.Disappearing += OnViewClosing;
             }
         }
 
@@ -222,51 +223,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             return registrationInfo?.ViewType == RootPage.GetType();
         }
-
-
-
-        #region View Disappearing event
-        private async void OnViewClosing(
-            object sender,
-            EventArgs eventArgs)
-        {
-            if (!(sender is Page page))
-            {
-                return;
-            }
-
-            if (Registrations == null ||
-                !Registrations.Any(
-                    registration => registration.ViewType == page.GetType()))
-            {
-                DetachDisappearingEventListener(page);
-                return;
-            }
-
-            if (!(page.BindingContext is IHandleClosing viewModel))
-            {
-                DetachDisappearingEventListener(page);
-                return;
-            }
-
-            await viewModel.OnClosing();
-
-            DetachDisappearingEventListener(page);
-        }
-
-
-        private void DetachDisappearingEventListener(
-            Page closedPage)
-        {
-            if (closedPage == null)
-            {
-                return;
-            }
-
-            closedPage.Disappearing -= OnViewClosing;
-        }
-        #endregion
-
 
 
         public static void SetupLogging(

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.cs
@@ -48,6 +48,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
                     _ => Application.Current.MainPage,
                 };
 
+
                 return rootPage;
             }
         }

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
@@ -40,29 +40,29 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             Log?.Info($"Registered ViewModel of type {registrationInfo.ViewModelType.Name} to page {registrationInfo.ViewType.Name}.");
         }
 
-        public INavigationRegistration Register<TViewModel, TView>()
+        //public INavigationRegistration Register<TViewModel, TView>()
 
-            where TViewModel : IViewModel
-            where TView : class
-        {
-            var registrationInfo = new NavigationRegistration
-            {
-                ViewModelType = typeof(TViewModel),
-                ViewType = typeof(TView),
-                Platform = Device.RuntimePlatform.ToDevicePlatform()
-            };
+        //    where TViewModel : IViewModel
+        //    where TView : class
+        //{
+        //    var registrationInfo = new NavigationRegistration
+        //    {
+        //        ViewModelType = typeof(TViewModel),
+        //        ViewType = typeof(TView),
+        //        Platform = Device.RuntimePlatform.ToDevicePlatform()
+        //    };
 
-            RegisterInternal(registrationInfo);
+        //    RegisterInternal(registrationInfo);
 
-            if (registrationInfo.PreCreateInstance)
-            {
-                Task.Run(() => CreateCachedPage(registrationInfo.ViewType));
-            }
+        //    if (registrationInfo.PreCreateInstance)
+        //    {
+        //        Task.Run(() => CreateCachedPage(registrationInfo.ViewType));
+        //    }
 
-            Log?.Info($"Registered ViewModel of type {registrationInfo.ViewModelType.Name} to page {registrationInfo.ViewType.Name}.");
+        //    Log?.Info($"Registered ViewModel of type {registrationInfo.ViewModelType.Name} to page {registrationInfo.ViewType.Name}.");
 
-            return registrationInfo;
-        }
+        //    return registrationInfo;
+        //}
 
 
         /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.Unregister{TViewModelInterface}" />

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
@@ -40,31 +40,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             Log?.Info($"Registered ViewModel of type {registrationInfo.ViewModelType.Name} to page {registrationInfo.ViewType.Name}.");
         }
 
-        //public INavigationRegistration Register<TViewModel, TView>()
-
-        //    where TViewModel : IViewModel
-        //    where TView : class
-        //{
-        //    var registrationInfo = new NavigationRegistration
-        //    {
-        //        ViewModelType = typeof(TViewModel),
-        //        ViewType = typeof(TView),
-        //        Platform = Device.RuntimePlatform.ToDevicePlatform()
-        //    };
-
-        //    RegisterInternal(registrationInfo);
-
-        //    if (registrationInfo.PreCreateInstance)
-        //    {
-        //        Task.Run(() => CreateCachedPage(registrationInfo.ViewType));
-        //    }
-
-        //    Log?.Info($"Registered ViewModel of type {registrationInfo.ViewModelType.Name} to page {registrationInfo.ViewType.Name}.");
-
-        //    return registrationInfo;
-        //}
-
-
         /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.Unregister{TViewModelInterface}" />
         public void Unregister<TViewModel>()
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.registration.cs
@@ -205,21 +205,15 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
 
-        internal static void ThrowIfNotRegistered<TViewModelInterface>(
+        internal static void ThrowIfNotRegistered<TViewModel>(
             Type typeOfView = null)
         {
-            if (IsRegistered(typeof(TViewModelInterface), typeOfView))
+            if (IsRegistered(typeof(TViewModel), typeOfView))
             {
                 return;
             }
 
-            // todo: which exception type fits best?
-            var notRegisteredException = new InvalidOperationException(
-                $"There is no reference from viewmodel type {typeof(TViewModelInterface).Name} to a page.");
-
-            Log?.Error(notRegisteredException);
-
-            throw notRegisteredException;
+            ThrowNotRegisteredException<TViewModel>();
         }
 
 
@@ -241,6 +235,19 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             }
 
             return true;
+        }
+
+
+        private static void ThrowNotRegisteredException<TViewModel>()
+        {
+            // todo: which exception type fits best?
+            var notRegisteredException = new InvalidOperationException(
+                $"There is no reference from viewmodel type {typeof(TViewModel).Name} to a page.");
+
+            Log?.Error(notRegisteredException);
+
+
+            throw notRegisteredException;
         }
     }
 }

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
@@ -80,6 +80,12 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
                 await PopToRootAsync()
                     .ConfigureAwait(false);
             }
+            else if (IsTab(
+                registration.ViewType))
+            {
+                await SetTabAsync(registration.ViewType)
+                    .ConfigureAwait(false);
+            }
             else
             {
                 var viewModelInstance = await InitializeViewModelAsync<TViewModel>()
@@ -322,9 +328,9 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             {
                 var tab = tabbedPage
                     .Children
-                    .FirstOrDefault(c => IsPageOfType(
-                        c,
-                        page.GetType()));
+                    .FirstOrDefault(tab => IsPageOfType(
+                        tab,
+                        selectedTabType));
 
                 if (tab == null)
                 {

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
@@ -236,7 +236,8 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             view.BindingContext = viewModel;
 
-            if (viewModel is IHandleClosing)
+            if (viewModel is IHandleClosing ||
+                registration.InterestedType != null)
             {
                 view.Disappearing += OnViewClosing;
             }
@@ -352,7 +353,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
                     animated: Configuration.UseAnimations);
             });
         }
-               
 
 
 

--- a/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
+++ b/src/Navigation/Xamarin.Forms/Navigation.Xamarin.Forms/Service/NavigationService.show.cs
@@ -19,26 +19,46 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             where TViewModel : class, IViewModel
         {
-            ThrowIfNotRegistered<TViewModel>();
+            if (!TryGetRegistration(
+                typeof(TViewModel),
+                out var registration))
+            {
+                ThrowNotRegisteredException<TViewModel>();
+            }
+
 
             if (IsRoot<TViewModel>())
             {
-                await PopToRootAsync();
-                return;
+                await PopToRootAsync()
+                    .ConfigureAwait(false);
             }
+            else if (IsTab(
+                registration.ViewType))
+            {
+                await SetTabAsync(registration.ViewType)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                var viewModelInstance = await InitializeViewModelAsync<TViewModel>()
+                    .ConfigureAwait(false);
 
-            var viewModelInstance = await InitializeViewModelAsync<TViewModel>()
-                .ConfigureAwait(false);
-
-            var page = CreateView<TViewModel>(
-                viewModelInstance);
+                var page = CreateView<TViewModel>(
+                    viewModelInstance);
 
 
-            var showAsyncFunc = BuildShowAsyncFunc(
-                page);
-
-            await showAsyncFunc.Invoke(page)
-                .ConfigureAwait(false);
+                if (IsDetail(
+                    registration.ViewType))
+                {
+                    await SetDetailAsync(page)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await PushAsync(page)
+                        .ConfigureAwait(false);
+                }
+            }
         }
 
         /// <inheritdoc cref="CodeMonkeys.Navigation.INavigationService.ShowAsync{TViewModelInterface, TModel}(TModel)" />
@@ -47,27 +67,40 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             where TViewModel : class, IViewModel<TData>
         {
-            ThrowIfNotRegistered<TViewModel>();
+            if (!TryGetRegistration(
+                typeof(TViewModel),
+                out var registration))
+            {
+                ThrowNotRegisteredException<TViewModel>();
+            }
+
 
             if (IsRoot<TViewModel>())
             {
-                await PopToRootAsync();
-                return;
+                await PopToRootAsync()
+                    .ConfigureAwait(false);
             }
+            else
+            {
+                var viewModelInstance = await InitializeViewModelAsync<TViewModel>()
+                    .ConfigureAwait(false);
 
-            var viewModelInstance = 
-                await InitializeViewModelAsync<TViewModel, TData>(data)
-                .ConfigureAwait(false);
-
-            var page = CreateView<TViewModel>(
-                viewModelInstance);
+                var page = CreateView<TViewModel>(
+                    viewModelInstance);
 
 
-            var showAsyncFunc = BuildShowAsyncFunc(
-                page);
-
-            await showAsyncFunc.Invoke(
-               page);
+                if (IsDetail(
+                    registration.ViewType))
+                {
+                    await SetDetailAsync(page)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await PushAsync(page)
+                        .ConfigureAwait(false);
+                }
+            }
         }
 
 
@@ -112,7 +145,6 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
             await PushModalAsync(page)
                 .ConfigureAwait(false);
         }
-
 
 
         protected async Task<TViewModel> InitializeViewModelAsync<TViewModel>()
@@ -218,23 +250,26 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
 
 
-        private Func<Page, Task> BuildShowAsyncFunc(
-            Page page)
+        private bool IsTab(
+            Type viewType)
         {
-            if (RootPage is MasterDetailPage &&
-                page is DetailPage)
+            if (!(RootPage is TabbedPage tabbedPage) ||
+                !viewType.IsAssignableFrom(typeof(TabPage)))
             {
-                return SetDetailAsync;
+                return false;
             }
-            else if (RootPage is TabbedPage &&
-                page is TabPage)
-            {
-                return SetTabAsync;
-            }
-            else
-            {
-                return PushAsync;
-            }
+
+
+            return tabbedPage.Children.Any(
+                tab => tab.GetType() == viewType);
+        }
+
+
+        private bool IsDetail(
+            Type viewType)
+        {
+            return RootPage is MasterDetailPage &&
+                viewType.IsAssignableFrom(typeof(DetailPage));
         }
 
 
@@ -257,7 +292,8 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         private async Task SetDetailAsync(
             Page page)
         {
-            if (!(Application.Current.MainPage is MasterDetailPage masterDetailPage))
+            if (!(Application.Current.MainPage is MasterDetailPage masterDetailPage) ||
+                !page.GetType().IsAssignableFrom(typeof(DetailPage)))
             {
                 return;
             }
@@ -271,37 +307,31 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         }
 
         private async Task SetTabAsync(
-            Page page)
+            Type selectedTabType)
         {
-            var mainPage = Application.Current.MainPage;
-
-            if (mainPage is NavigationPage navigation)
-            {
-                mainPage = navigation.RootPage;
-            }
-
-            if (!(mainPage is TabbedPage tabbedPage))
+            if (!IsTab(selectedTabType))
             {
                 return;
             }
 
 
+            var tabbedPage = RootPage as TabbedPage;
+
             await Device.InvokeOnMainThreadAsync(() =>
             {
-                var tab = tabbedPage
-                    .Children
-                    .FirstOrDefault(c => c.GetType() == page.GetType());
+                var selectedTab = tabbedPage.Children
+                    .FirstOrDefault(tab => tab.GetType() == selectedTabType);
 
-                if (tab == null)
+                if (selectedTab == null)
                 {
                     Log?.Error(
-                        $"{tabbedPage.GetType().Name} does not contain requested view {page.GetType().Name}!");
+                        $"{tabbedPage.GetType().Name} does not contain requested view {selectedTabType.Name}!");
 
                     return;
                 }
 
 
-                tabbedPage.CurrentPage = tab;
+                tabbedPage.CurrentPage = selectedTab;
             });
         }
 
@@ -309,7 +339,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
         private async Task PushModalAsync(
             Page page)
         {
-            if (Navigation == null)
+            if (CurrentPage?.Navigation == null)
             {
                 return;
             }
@@ -317,7 +347,7 @@ namespace CodeMonkeys.Navigation.Xamarin.Forms
 
             await Device.InvokeOnMainThreadAsync(() =>
             {
-                Navigation.PushModalAsync(
+                CurrentPage.Navigation.PushModalAsync(
                     page,
                     animated: Configuration.UseAnimations);
             });


### PR DESCRIPTION
## Proposed changes

Instead of using the `IListenToChildViewModelClosing` interfaces, that could only be used via `CloseAsync`, there is now the possibility to listen to any ViewModel closing by adding a listener in the navigation registration.

`navigationService.Register<SomeSubpageViewModel, SomeSubpage>().WithClosingListener<TListener>();`

`TListener` can be anything, as long as it implements the interface `IInterestedInClosing`

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
